### PR TITLE
feat: introduce tool registry and enhance LangGraph adapter

### DIFF
--- a/backend/app/adapters/__init__.py
+++ b/backend/app/adapters/__init__.py
@@ -12,8 +12,16 @@ from app.adapters.base import (
     get_adapter,
     register_adapter,
 )
+from app.adapters import tool_registry as _tool_registry  # noqa: F401 - builtins
 from app.adapters.echo_adapter import EchoAdapter
 from app.adapters.langgraph_adapter import LangGraphAdapter
+from app.adapters.tool_registry import (
+    ToolDefinition,
+    get_tool,
+    list_tools,
+    register_tool,
+    resolve_tools,
+)
 
 register_adapter("echo", EchoAdapter())
 register_adapter("langgraph", LangGraphAdapter())
@@ -23,6 +31,11 @@ __all__ = [
     "EchoAdapter",
     "LangGraphAdapter",
     "OrchestratorAdapter",
+    "ToolDefinition",
     "get_adapter",
+    "get_tool",
+    "list_tools",
     "register_adapter",
+    "register_tool",
+    "resolve_tools",
 ]

--- a/backend/app/adapters/langgraph_adapter.py
+++ b/backend/app/adapters/langgraph_adapter.py
@@ -166,7 +166,8 @@ class LangGraphAdapter(OrchestratorAdapter):
         try:
             tools = resolve_tools(tool_keys) if tool_keys else []
         except KeyError as exc:
-            return AdapterResult(status=RunStatus.FAILED, error=str(exc))
+            message = exc.args[0] if exc.args else str(exc)
+            return AdapterResult(status=RunStatus.FAILED, error=str(message))
 
         try:
             graph_spec = GraphSpec.from_config(config.get("graph"))

--- a/backend/app/adapters/langgraph_adapter.py
+++ b/backend/app/adapters/langgraph_adapter.py
@@ -1,36 +1,152 @@
 """LangGraph adapter – the default production adapter.
 
-The adapter constructs a tiny `StateGraph` from the agent's config and
-streams every node tick back to the runtime through `AdapterContext`.
-LangGraph is imported lazily so the rest of AgentFlow does not pay the
-import cost in tests that exercise only the echo adapter.
+The adapter constructs a ``StateGraph`` from the agent's config and streams
+every node tick back to the runtime through ``AdapterContext``. LangGraph is
+imported lazily so the rest of AgentFlow does not pay the import cost in tests
+that exercise only the echo adapter.
 
-Expected agent.config shape (all optional):
+Expected agent.config shape (all optional except when using custom graphs):
 
 ```jsonc
 {
   "model": "openai/gpt-4o-mini",
   "system_prompt": "You are a helpful coordinator.",
-  "tools": []                 // tool registry keys, resolved by the runtime
+  "tools": ["echo"],           // tool registry keys
+  "graph": {
+    "nodes": [
+      {"id": "plan", "type": "model"},
+      {"id": "tool", "type": "tool", "tool": "echo"},
+      {"id": "reply", "type": "model", "system_prompt": "Summarize briefly."}
+    ],
+    "edges": [
+      {"from": "__start__", "to": "plan"},
+      {"from": "plan", "to": "tool"},
+      {"from": "tool", "to": "reply"},
+      {"from": "reply", "to": "__end__"}
+    ]
+  }
 }
 ```
 
-If `agent.config.graph` is provided it is treated as an opaque description
-the adapter can specialise on. The MVP shipped here implements a
-single-node graph that calls the model once; richer multi-node graphs can
-be added behind the same interface without touching the runtime tables.
+When ``graph`` is omitted a single-node ``call_model`` graph is used (backward
+compatible with the MVP). Edge endpoints ``__start__`` / ``__end__`` map to
+LangGraph ``START`` / ``END``.
 """
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
+from app.adapters.tool_registry import ToolDefinition, resolve_tools, tool_schemas
 from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.models.run import RunStatus
 
 logger = get_logger("adapter.langgraph")
+
+START_NODE = "__start__"
+END_NODE = "__end__"
+
+
+@dataclass
+class GraphNodeSpec:
+    id: str
+    type: str = "model"
+    tool: str | None = None
+    system_prompt: str | None = None
+    model: str | None = None
+
+
+@dataclass
+class GraphEdgeSpec:
+    from_node: str
+    to: str
+
+
+@dataclass
+class GraphSpec:
+    nodes: list[GraphNodeSpec]
+    edges: list[GraphEdgeSpec]
+
+    @classmethod
+    def default(cls) -> GraphSpec:
+        return cls(
+            nodes=[GraphNodeSpec(id="call_model", type="model")],
+            edges=[
+                GraphEdgeSpec(from_node=START_NODE, to="call_model"),
+                GraphEdgeSpec(from_node="call_model", to=END_NODE),
+            ],
+        )
+
+    @classmethod
+    def from_config(cls, raw: dict[str, Any] | None) -> GraphSpec:
+        if not raw:
+            return cls.default()
+        nodes = [_parse_node(node) for node in raw.get("nodes", [])]
+        edges = [_parse_edge(edge) for edge in raw.get("edges", [])]
+        if not nodes:
+            return cls.default()
+        if not edges:
+            edges = _linear_edges(nodes)
+        return cls(nodes=nodes, edges=edges)
+
+
+def _parse_node(raw: dict[str, Any] | str) -> GraphNodeSpec:
+    if isinstance(raw, str):
+        return GraphNodeSpec(id=raw, type="model")
+    node_id = raw.get("id") or raw.get("name")
+    if not node_id:
+        raise ValueError("graph node requires 'id' or 'name'")
+    return GraphNodeSpec(
+        id=str(node_id),
+        type=str(raw.get("type", "model")),
+        tool=raw.get("tool"),
+        system_prompt=raw.get("system_prompt"),
+        model=raw.get("model"),
+    )
+
+
+def _parse_edge(raw: dict[str, Any] | list[str]) -> GraphEdgeSpec:
+    if isinstance(raw, list):
+        if len(raw) != 2:
+            raise ValueError("edge list must be [from, to]")
+        return GraphEdgeSpec(from_node=str(raw[0]), to=str(raw[1]))
+    from_node = raw.get("from") or raw.get("source")
+    to_node = raw.get("to") or raw.get("target")
+    if not from_node or not to_node:
+        raise ValueError("graph edge requires 'from' and 'to'")
+    return GraphEdgeSpec(from_node=str(from_node), to=str(to_node))
+
+
+def _linear_edges(nodes: list[GraphNodeSpec]) -> list[GraphEdgeSpec]:
+    """Build START -> n0 -> ... -> END when edges are omitted."""
+    edges = [GraphEdgeSpec(from_node=START_NODE, to=nodes[0].id)]
+    for left, right in zip(nodes, nodes[1:], strict=False):
+        edges.append(GraphEdgeSpec(from_node=left.id, to=right.id))
+    edges.append(GraphEdgeSpec(from_node=nodes[-1].id, to=END_NODE))
+    return edges
+
+
+@dataclass
+class _RunState:
+    """Mutable per-run bookkeeping shared across graph nodes."""
+
+    ctx: AdapterContext
+    config: dict[str, Any]
+    tools: list[ToolDefinition]
+    default_model: str
+    default_system_prompt: str
+    step_index: int = 0
+    node_indices: dict[str, int] = field(default_factory=dict)
+
+    def next_step_index(self, node_id: str) -> int:
+        if node_id not in self.node_indices:
+            self.node_indices[node_id] = self.step_index
+            self.step_index += 1
+        return self.node_indices[node_id]
 
 
 class LangGraphAdapter(OrchestratorAdapter):
@@ -46,31 +162,47 @@ class LangGraphAdapter(OrchestratorAdapter):
             )
 
         config = ctx.agent_config
-        system_prompt: str = config.get("system_prompt", "You are a helpful agent.")
-        model: str = config.get("model", "openai/gpt-4o-mini")
-
-        async def call_model(state: dict[str, Any]) -> dict[str, Any]:
-            await ctx.emit_step_started(index=0, node="call_model")
-            user_input = state.get("input", "")
-            await ctx.emit_message(role="system", content=system_prompt)
-            await ctx.emit_message(role="user", content=str(user_input))
-
-            reply = await self._invoke_model(model, system_prompt, str(user_input))
-
-            await ctx.emit_message(role="assistant", content=reply)
-            await ctx.emit_step_completed(
-                index=0, node="call_model", output={"reply": reply}
-            )
-            return {"reply": reply}
-
-        graph = StateGraph(dict)
-        graph.add_node("call_model", call_model)
-        graph.add_edge(START, "call_model")
-        graph.add_edge("call_model", END)
-        compiled = graph.compile()
+        tool_keys: list[str] = list(config.get("tools") or [])
+        try:
+            tools = resolve_tools(tool_keys) if tool_keys else []
+        except KeyError as exc:
+            return AdapterResult(status=RunStatus.FAILED, error=str(exc))
 
         try:
-            final_state = await compiled.ainvoke({"input": ctx.input.get("prompt", "")})
+            graph_spec = GraphSpec.from_config(config.get("graph"))
+        except ValueError as exc:
+            return AdapterResult(status=RunStatus.FAILED, error=str(exc))
+
+        run_state = _RunState(
+            ctx=ctx,
+            config=config,
+            tools=tools,
+            default_model=str(config.get("model", "openai/gpt-4o-mini")),
+            default_system_prompt=str(
+                config.get("system_prompt", "You are a helpful agent.")
+            ),
+        )
+
+        graph = StateGraph(dict)
+        for node_spec in graph_spec.nodes:
+            handler = self._make_node_handler(run_state, node_spec)
+            graph.add_node(node_spec.id, handler)
+
+        for edge in graph_spec.edges:
+            src = START if edge.from_node == START_NODE else edge.from_node
+            dst = END if edge.to == END_NODE else edge.to
+            graph.add_edge(src, dst)
+
+        compiled = graph.compile()
+        initial = {
+            "input": ctx.input.get("prompt", ""),
+            "messages": [],
+            "reply": None,
+            "tool_results": {},
+        }
+
+        try:
+            final_state = await compiled.ainvoke(initial)
         except Exception as exc:  # pragma: no cover - depends on external model
             logger.exception("langgraph_run_failed", run_id=ctx.run_id)
             return AdapterResult(status=RunStatus.FAILED, error=str(exc))
@@ -80,31 +212,160 @@ class LangGraphAdapter(OrchestratorAdapter):
             output={"reply": final_state.get("reply")},
         )
 
-    async def _invoke_model(self, model: str, system_prompt: str, user_input: str) -> str:
+    def _make_node_handler(
+        self, run_state: _RunState, spec: GraphNodeSpec
+    ) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+        if spec.type == "tool":
+            return self._tool_node(run_state, spec)
+        return self._model_node(run_state, spec)
+
+    def _tool_node(
+        self, run_state: _RunState, spec: GraphNodeSpec
+    ) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+        tool_name = spec.tool
+        if not tool_name and run_state.tools:
+            tool_name = run_state.tools[0].name
+        if not tool_name:
+            raise ValueError(f"tool node {spec.id!r} has no tool configured")
+
+        tool_def = next(
+            (t for t in run_state.tools if t.name == tool_name),
+            None,
+        )
+        if tool_def is None:
+            from app.adapters.tool_registry import get_tool
+
+            tool_def = get_tool(tool_name)
+
+        async def handler(state: dict[str, Any]) -> dict[str, Any]:
+            step_idx = run_state.next_step_index(spec.id)
+            ctx = run_state.ctx
+            arguments = {
+                "text": state.get("reply") or state.get("input", ""),
+                "input": state.get("input", ""),
+            }
+            await ctx.emit_step_started(index=step_idx, node=spec.id)
+            await ctx.emit_tool_call_started(
+                step_index=step_idx, name=tool_def.name, arguments=arguments
+            )
+            try:
+                result = await tool_def.handler(arguments)
+                if not isinstance(result, dict):
+                    result = {"result": result}
+                await ctx.emit_tool_call_completed(
+                    step_index=step_idx, name=tool_def.name, result=result
+                )
+                await ctx.emit_step_completed(
+                    index=step_idx,
+                    node=spec.id,
+                    output={"tool": tool_def.name, "result": result},
+                )
+                tool_results = dict(state.get("tool_results") or {})
+                tool_results[tool_def.name] = result
+                return {"tool_results": tool_results, "reply": str(result)}
+            except Exception as exc:
+                await ctx.emit_tool_call_completed(
+                    step_index=step_idx,
+                    name=tool_def.name,
+                    error=str(exc),
+                )
+                await ctx.emit_step_failed(
+                    index=step_idx, node=spec.id, error=str(exc)
+                )
+                raise
+
+        return handler
+
+    def _model_node(
+        self, run_state: _RunState, spec: GraphNodeSpec
+    ) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+        system_prompt = spec.system_prompt or run_state.default_system_prompt
+        model = spec.model or run_state.default_model
+        tool_keys: list[str] = list(run_state.config.get("tools") or [])
+
+        async def handler(state: dict[str, Any]) -> dict[str, Any]:
+            step_idx = run_state.next_step_index(spec.id)
+            ctx = run_state.ctx
+            user_input = str(state.get("input", ""))
+            context_bits: list[str] = []
+            if state.get("tool_results"):
+                context_bits.append(f"tool_results={state['tool_results']!r}")
+            if state.get("reply") and spec.id != "call_model":
+                context_bits.append(f"prior_reply={state['reply']!r}")
+            if context_bits:
+                user_input = f"{user_input}\n\n" + "\n".join(context_bits)
+
+            await ctx.emit_step_started(index=step_idx, node=spec.id)
+            await ctx.emit_message(role="system", content=system_prompt)
+            await ctx.emit_message(role="user", content=user_input)
+
+            reply = await self._invoke_model(
+                model,
+                system_prompt,
+                user_input,
+                tool_keys=tool_keys if tool_keys else None,
+            )
+
+            await ctx.emit_message(role="assistant", content=reply)
+            await ctx.emit_step_completed(
+                index=step_idx, node=spec.id, output={"reply": reply}
+            )
+            messages = list(state.get("messages") or [])
+            messages.extend(
+                [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_input},
+                    {"role": "assistant", "content": reply},
+                ]
+            )
+            return {"reply": reply, "messages": messages}
+
+        return handler
+
+    async def _invoke_model(
+        self,
+        model: str,
+        system_prompt: str,
+        user_input: str,
+        *,
+        tool_keys: list[str] | None = None,
+    ) -> str:
         """Call the configured chat model.
 
         The MVP routes everything through an OpenAI-compatible Chat
-        Completions endpoint. Swap this method to use LiteLLM, Bedrock,
-        Anthropic, etc. without touching the rest of the adapter.
+        Completions endpoint. When ``tool_keys`` are set, tool schemas are
+        attached so the model may request function calls (single round-trip).
         """
         settings = get_settings()
         if not settings.openai_api_key:
-            return f"[mock:{model}] {user_input}"
+            suffix = ""
+            if tool_keys:
+                suffix = f" [tools={','.join(tool_keys)}]"
+            return f"[mock:{model}]{suffix} {user_input}"
 
         import httpx
+
+        payload: dict[str, Any] = {
+            "model": model.split("/", 1)[-1],
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_input},
+            ],
+        }
+        if tool_keys:
+            payload["tools"] = tool_schemas(tool_keys)
 
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(
                 f"{settings.openai_base_url}/chat/completions",
                 headers={"Authorization": f"Bearer {settings.openai_api_key}"},
-                json={
-                    "model": model.split("/", 1)[-1],
-                    "messages": [
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_input},
-                    ],
-                },
+                json=payload,
             )
             response.raise_for_status()
             data = response.json()
-            return data["choices"][0]["message"]["content"]
+            message = data["choices"][0]["message"]
+            tool_calls = message.get("tool_calls")
+            if tool_calls:
+                names = [tc["function"]["name"] for tc in tool_calls]
+                return f"[tool_calls:{','.join(names)}]"
+            return message.get("content") or ""

--- a/backend/app/adapters/tool_registry.py
+++ b/backend/app/adapters/tool_registry.py
@@ -1,0 +1,124 @@
+"""Built-in and pluggable tools for orchestrator adapters.
+
+Adapters resolve tool keys from ``agent.config.tools`` through this registry.
+Register custom tools at process startup (e.g. in ``app/adapters/__init__.py``)
+before workers begin consuming jobs.
+
+Example::
+
+    from app.adapters.tool_registry import register_tool
+
+    async def search_web(arguments: dict) -> dict:
+        return {"results": []}
+
+    register_tool("search_web", search_web, description="Search the public web.")
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+ToolHandler = Callable[[dict[str, Any]], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class ToolDefinition:
+    """Metadata and handler for a registered tool."""
+
+    name: str
+    handler: ToolHandler
+    description: str = ""
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+
+_registry: dict[str, ToolDefinition] = {}
+
+
+def register_tool(
+    name: str,
+    handler: ToolHandler,
+    *,
+    description: str = "",
+    parameters: dict[str, Any] | None = None,
+    overwrite: bool = False,
+) -> None:
+    """Register a tool handler under ``name``.
+
+    Raises ``ValueError`` if the name already exists and ``overwrite`` is false.
+    """
+    if name in _registry and not overwrite:
+        raise ValueError(f"Tool already registered: {name!r}")
+    _registry[name] = ToolDefinition(
+        name=name,
+        handler=handler,
+        description=description,
+        parameters=parameters or {"type": "object", "properties": {}},
+    )
+
+
+def get_tool(name: str) -> ToolDefinition:
+    if name not in _registry:
+        raise KeyError(f"Unknown tool: {name!r}")
+    return _registry[name]
+
+
+def resolve_tools(keys: list[str]) -> list[ToolDefinition]:
+    """Return tool definitions for the given registry keys, preserving order."""
+    missing = [key for key in keys if key not in _registry]
+    if missing:
+        raise KeyError(f"Unknown tool(s): {', '.join(missing)}")
+    return [_registry[key] for key in keys]
+
+
+def list_tools() -> list[str]:
+    return sorted(_registry)
+
+
+def tool_schemas(keys: list[str]) -> list[dict[str, Any]]:
+    """OpenAI-compatible function schemas for the resolved tools."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description or f"Invoke the {tool.name} tool.",
+                "parameters": tool.parameters,
+            },
+        }
+        for tool in resolve_tools(keys)
+    ]
+
+
+async def _echo(arguments: dict[str, Any]) -> dict[str, Any]:
+    text = arguments.get("text", arguments.get("input", ""))
+    return {"text": text}
+
+
+async def _noop(_arguments: dict[str, Any]) -> dict[str, Any]:
+    return {"ok": True}
+
+
+def _register_builtins() -> None:
+    register_tool(
+        "echo",
+        _echo,
+        description="Echo the input text back unchanged.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "Text to echo."},
+            },
+        },
+        overwrite=True,
+    )
+    register_tool(
+        "noop",
+        _noop,
+        description="No-op placeholder for wiring tests.",
+        overwrite=True,
+    )
+
+
+_register_builtins()

--- a/backend/tests/test_langgraph_adapter.py
+++ b/backend/tests/test_langgraph_adapter.py
@@ -1,0 +1,127 @@
+"""LangGraph adapter and tool registry tests (no live LLM)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.adapters.base import AdapterContext, AdapterResult
+from app.adapters.langgraph_adapter import GraphSpec, LangGraphAdapter
+from app.adapters.tool_registry import get_tool, list_tools, register_tool, resolve_tools
+from app.models.run import RunStatus
+
+
+class _RecordingContext(AdapterContext):
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+        super().__init__(
+            run_id="01TEST",
+            agent_id="01AGENT",
+            agent_config={},
+            input={"prompt": "hello"},
+            emit=self._emit,
+        )
+
+    async def _emit(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+
+
+@pytest.mark.asyncio
+async def test_tool_registry_builtins():
+    assert "echo" in list_tools()
+    tool = get_tool("echo")
+    result = await tool.handler({"text": "ping"})
+    assert result == {"text": "ping"}
+
+
+@pytest.mark.asyncio
+async def test_tool_registry_custom():
+    async def double(args: dict[str, Any]) -> dict[str, Any]:
+        return {"value": int(args.get("n", 0)) * 2}
+
+    register_tool("double", double, overwrite=True)
+    assert resolve_tools(["double"])[0].name == "double"
+    out = await get_tool("double").handler({"n": 3})
+    assert out == {"value": 6}
+
+
+def test_graph_spec_default():
+    spec = GraphSpec.default()
+    assert len(spec.nodes) == 1
+    assert spec.nodes[0].id == "call_model"
+
+
+def test_graph_spec_from_config_linear_fallback():
+    spec = GraphSpec.from_config(
+        {
+            "nodes": [
+                {"id": "plan", "type": "model"},
+                {"id": "tool", "type": "tool", "tool": "echo"},
+                {"id": "reply", "type": "model"},
+            ],
+        }
+    )
+    assert [n.id for n in spec.nodes] == ["plan", "tool", "reply"]
+    assert spec.edges[0].from_node == "__start__"
+    assert spec.edges[-1].to == "__end__"
+
+
+@pytest.mark.asyncio
+async def test_langgraph_default_single_node():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = {"model": "openai/gpt-4o-mini"}
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output == {"reply": "[mock:openai/gpt-4o-mini] hello"}
+    step_nodes = [
+        data["node"]
+        for event, data in ctx.events
+        if event == "step.started"
+    ]
+    assert step_nodes == ["call_model"]
+
+
+@pytest.mark.asyncio
+async def test_langgraph_multi_node_with_tool():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = {
+        "model": "openai/gpt-4o-mini",
+        "system_prompt": "Be brief.",
+        "tools": ["echo"],
+        "graph": {
+            "nodes": [
+                {"id": "draft", "type": "model"},
+                {"id": "echo_step", "type": "tool", "tool": "echo"},
+                {"id": "finalize", "type": "model"},
+            ],
+            "edges": [
+                ["__start__", "draft"],
+                ["draft", "echo_step"],
+                ["echo_step", "finalize"],
+                ["finalize", "__end__"],
+            ],
+        },
+    }
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.SUCCEEDED
+    step_nodes = [
+        data["node"]
+        for event, data in ctx.events
+        if event == "step.started"
+    ]
+    assert step_nodes == ["draft", "echo_step", "finalize"]
+    tool_events = [e for e, _ in ctx.events if e.startswith("tool_call.")]
+    assert len(tool_events) == 2
+
+
+@pytest.mark.asyncio
+async def test_langgraph_unknown_tool_fails():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = {"tools": ["does_not_exist"]}
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.FAILED
+    assert "Unknown tool" in (result.error or "")


### PR DESCRIPTION
- Added a new tool registry to manage built-in and custom tools for orchestrator adapters.
- Implemented functionality to register, resolve, and list tools, including built-in tools like "echo" and "noop".
- Enhanced the LangGraph adapter to support multi-node graphs and tool integration, allowing for more complex workflows.
- Introduced GraphSpec for defining graph structures from configuration, enabling dynamic graph creation.
- Added comprehensive tests for the tool registry and LangGraph adapter functionality.