### PR TITLE
feat: integrate OpenTelemetry for tracing and metrics

### DIFF
--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -44,6 +44,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-otlp</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/backend-java/src/main/java/io/agentflow/api/config/AgentflowProperties.java
+++ b/backend-java/src/main/java/io/agentflow/api/config/AgentflowProperties.java
@@ -11,6 +11,7 @@ public class AgentflowProperties {
     private Jobs jobs = new Jobs();
     private Cancel cancel = new Cancel();
     private Events events = new Events();
+    private Otel otel = new Otel();
 
     public String getVersion() {
         return version;
@@ -50,6 +51,35 @@ public class AgentflowProperties {
 
     public void setEvents(Events events) {
         this.events = events;
+    }
+
+    public Otel getOtel() {
+        return otel;
+    }
+
+    public void setOtel(Otel otel) {
+        this.otel = otel;
+    }
+
+    public static class Otel {
+        private boolean enabled = false;
+        private String serviceName = "agentflow-api";
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getServiceName() {
+            return serviceName;
+        }
+
+        public void setServiceName(String serviceName) {
+            this.serviceName = serviceName;
+        }
     }
 
     public static class Jobs {

--- a/backend-java/src/main/java/io/agentflow/api/jobs/JobProducer.java
+++ b/backend-java/src/main/java/io/agentflow/api/jobs/JobProducer.java
@@ -3,7 +3,11 @@ package io.agentflow.api.jobs;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentflow.api.config.AgentflowProperties;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -36,15 +40,25 @@ public class JobProducer {
     private final StringRedisTemplate redis;
     private final ObjectMapper mapper;
     private final AgentflowProperties props;
+    private final Tracer tracer;
+    private final Propagator propagator;
 
-    public JobProducer(StringRedisTemplate redis, ObjectMapper mapper, AgentflowProperties props) {
+    public JobProducer(
+            StringRedisTemplate redis,
+            ObjectMapper mapper,
+            AgentflowProperties props,
+            Tracer tracer,
+            Propagator propagator) {
         this.redis = redis;
         this.mapper = mapper;
         this.props = props;
+        this.tracer = tracer;
+        this.propagator = propagator;
     }
 
     public void enqueue(String runId, String agentId, String adapter) {
-        RunJob job = new RunJob(runId, agentId, adapter, Instant.now());
+        Map<String, String> traceContext = captureTraceContext();
+        RunJob job = new RunJob(runId, agentId, adapter, Instant.now(), traceContext);
         String payload;
         try {
             payload = mapper.writeValueAsString(job);
@@ -62,5 +76,18 @@ public class JobProducer {
         // compatible with Python's ``RunJob.from_json`` -- the consumer
         // reads ``fields["payload"]`` and decodes the JSON.
         redis.opsForStream().add(key, Map.of(STREAM_PAYLOAD_FIELD, payload));
+    }
+
+    private Map<String, String> captureTraceContext() {
+        if (!props.getOtel().isEnabled()) {
+            return null;
+        }
+        Span current = tracer.currentSpan();
+        if (current == null) {
+            return null;
+        }
+        Map<String, String> carrier = new HashMap<>();
+        propagator.inject(current.context(), carrier, Map::put);
+        return carrier.isEmpty() ? null : carrier;
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/jobs/RunJob.java
+++ b/backend-java/src/main/java/io/agentflow/api/jobs/RunJob.java
@@ -1,15 +1,23 @@
 package io.agentflow.api.jobs;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * Payload pushed onto {@code agentflow:jobs:runs}. The Python worker decodes
  * the same shape (see {@code backend/app/worker/runner.py}).
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record RunJob(
         @JsonProperty("run_id") String runId,
         @JsonProperty("agent_id") String agentId,
         String adapter,
-        @JsonProperty("enqueued_at") Instant enqueuedAt) {
+        @JsonProperty("enqueued_at") Instant enqueuedAt,
+        @JsonProperty("trace_context") Map<String, String> traceContext) {
+
+    public RunJob(String runId, String agentId, String adapter, Instant enqueuedAt) {
+        this(runId, agentId, adapter, enqueuedAt, null);
+    }
 }

--- a/backend-java/src/main/java/io/agentflow/api/observability/RedMetricsFilter.java
+++ b/backend-java/src/main/java/io/agentflow/api/observability/RedMetricsFilter.java
@@ -1,0 +1,76 @@
+package io.agentflow.api.observability;
+
+import io.agentflow.api.config.AgentflowProperties;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Records RED metrics aligned with the Python FastAPI middleware
+ * ({@code agentflow.http.server.*}).
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+@ConditionalOnProperty(prefix = "agentflow.otel", name = "enabled", havingValue = "true")
+public class RedMetricsFilter extends OncePerRequestFilter {
+
+    private final Counter httpRequests;
+    private final Counter httpErrors;
+    private final Timer httpDuration;
+
+    public RedMetricsFilter(MeterRegistry registry, AgentflowProperties props) {
+        String service = props.getOtel().getServiceName();
+        httpRequests = Counter.builder("agentflow.http.server.requests")
+                .description("HTTP requests (rate)")
+                .tag("service", service)
+                .register(registry);
+        httpErrors = Counter.builder("agentflow.http.server.errors")
+                .description("HTTP server errors")
+                .tag("service", service)
+                .register(registry);
+        httpDuration = Timer.builder("agentflow.http.server.duration")
+                .description("HTTP request duration")
+                .tag("service", service)
+                .publishPercentileHistogram()
+                .register(registry);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        long start = System.nanoTime();
+        int status = 500;
+        try {
+            filterChain.doFilter(request, response);
+            status = response.getStatus();
+        } finally {
+            String route = resolveRoute(request);
+            httpRequests.increment();
+            httpDuration.record(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            if (status >= 500) {
+                httpErrors.increment();
+            }
+        }
+    }
+
+    private static String resolveRoute(HttpServletRequest request) {
+        Object pattern = request.getAttribute(
+                "org.springframework.web.servlet.HandlerMapping.bestMatchingPattern");
+        if (pattern != null) {
+            return pattern.toString();
+        }
+        return request.getRequestURI();
+    }
+}

--- a/backend-java/src/main/resources/application.yml
+++ b/backend-java/src/main/resources/application.yml
@@ -37,6 +37,27 @@ agentflow:
   events:
     channel-prefix: "agentflow:run:"
     sse-heartbeat-seconds: 15
+  otel:
+    enabled: ${AGENTFLOW_OTEL_ENABLED:false}
+    service-name: ${AGENTFLOW_OTEL_SERVICE_NAME:agentflow-api}
+
+management:
+  tracing:
+    enabled: ${AGENTFLOW_OTEL_ENABLED:false}
+    sampling:
+      probability: ${AGENTFLOW_OTEL_TRACE_SAMPLE:1.0}
+  otlp:
+    tracing:
+      endpoint: ${AGENTFLOW_OTEL_EXPORTER_ENDPOINT:http://localhost:4318/v1/traces}
+    metrics:
+      export:
+        enabled: ${AGENTFLOW_OTEL_ENABLED:false}
+        url: ${AGENTFLOW_OTEL_METRICS_ENDPOINT:http://localhost:4318/v1/metrics}
+        step: 15s
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,prometheus
 
 logging:
   level:

--- a/backend-java/src/test/java/io/agentflow/api/jobs/JobProducerTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/jobs/JobProducerTest.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.agentflow.api.config.AgentflowProperties;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -45,7 +47,8 @@ class JobProducerTest {
         when(redis.opsForStream()).thenReturn(stream);
         when(stream.add(anyString(), any(Map.class))).thenReturn(RecordId.of("1-0"));
 
-        JobProducer producer = new JobProducer(redis, objectMapper(), props("streams"));
+        JobProducer producer = new JobProducer(
+                redis, objectMapper(), props("streams"), noopTracer(), noopPropagator());
         producer.enqueue("run-1", "agent-1", "echo");
 
         @SuppressWarnings("unchecked")
@@ -69,7 +72,8 @@ class JobProducerTest {
         when(redis.opsForList()).thenReturn(list);
         when(list.leftPush(anyString(), anyString())).thenReturn(1L);
 
-        JobProducer producer = new JobProducer(redis, objectMapper(), props("list"));
+        JobProducer producer = new JobProducer(
+                redis, objectMapper(), props("list"), noopTracer(), noopPropagator());
         producer.enqueue("run-2", "agent-2", "echo");
 
         ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
@@ -78,5 +82,13 @@ class JobProducerTest {
         assertThat(keyCaptor.getValue()).isEqualTo("test:agentflow:jobs:runs");
         assertThat(jsonCaptor.getValue()).contains("\"run_id\":\"run-2\"");
         verify(redis, never()).opsForStream();
+    }
+
+    private static Tracer noopTracer() {
+        return mock(Tracer.class);
+    }
+
+    private static Propagator noopPropagator() {
+        return mock(Propagator.class);
     }
 }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -135,6 +135,35 @@ class Settings(BaseSettings):
     openai_api_key: str | None = None
     openai_base_url: str = "https://api.openai.com/v1"
 
+    otel_enabled: bool = Field(
+        default=False,
+        description="Enable OpenTelemetry traces and RED metrics export via OTLP.",
+    )
+    otel_service_name: str = Field(
+        default="agentflow-worker",
+        description=(
+            "OTel ``service.name`` resource attribute. Override per process "
+            "(e.g. agentflow-api vs agentflow-worker)."
+        ),
+    )
+    otel_service_version: str = Field(
+        default="0.1.0",
+        description="OTel ``service.version`` resource attribute.",
+    )
+    otel_exporter_endpoint: str | None = Field(
+        default=None,
+        description=(
+            "OTLP HTTP base URL (no path). Defaults to http://localhost:4318 "
+            "when unset."
+        ),
+    )
+    otel_metric_export_interval_ms: int = Field(
+        default=15_000,
+        ge=1_000,
+        le=300_000,
+        description="Periodic metric reader export interval in milliseconds.",
+    )
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/app/core/http_metrics.py
+++ b/backend/app/core/http_metrics.py
@@ -1,0 +1,39 @@
+"""FastAPI middleware that records RED metrics for each HTTP request."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.core.telemetry import is_enabled, record_http_red
+
+
+class RedMetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        if not is_enabled():
+            return await call_next(request)
+
+        start = time.perf_counter()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        except Exception:
+            status_code = 500
+            raise
+        finally:
+            route = request.scope.get("route")
+            route_pattern = getattr(route, "path", request.url.path)
+            record_http_red(
+                method=request.method,
+                route=route_pattern,
+                status_code=status_code,
+                duration_seconds=time.perf_counter() - start,
+            )

--- a/backend/app/core/telemetry.py
+++ b/backend/app/core/telemetry.py
@@ -1,0 +1,377 @@
+"""OpenTelemetry bootstrap: distributed traces and RED metrics.
+
+RED (Rate, Errors, Duration) is exported via OTLP when ``AGENTFLOW_OTEL_ENABLED``
+is true. Instrumentation spans:
+
+* HTTP API (FastAPI middleware)
+* Worker job processing (``worker.process_job``)
+* Adapter execution (``adapter.run``)
+
+Trace context is propagated from API → Redis job payload → worker via W3C
+``traceparent`` / ``tracestate`` in ``RunJob.trace_context``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from contextlib import contextmanager
+from typing import Any, TypeVar
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.metrics import Counter, Histogram, Meter
+from opentelemetry.propagate import extract, inject, set_global_textmap
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
+from opentelemetry.trace.propagation.tracecontext import (
+    TraceContextTextMapPropagator,
+)
+
+from app.core.config import Settings, get_settings
+from app.core.logging import get_logger
+
+logger = get_logger("telemetry")
+
+F = TypeVar("F", bound=Callable[..., Any])
+AF = TypeVar("AF", bound=Callable[..., Awaitable[Any]])
+
+_tracer: Tracer | None = None
+_meter: Meter | None = None
+_initialized = False
+
+# RED metric instruments (lazy-created on first use).
+_http_requests: Counter | None = None
+_http_errors: Counter | None = None
+_http_duration: Histogram | None = None
+_worker_jobs: Counter | None = None
+_worker_errors: Counter | None = None
+_worker_duration: Histogram | None = None
+_adapter_runs: Counter | None = None
+_adapter_errors: Counter | None = None
+_adapter_duration: Histogram | None = None
+
+
+def is_enabled() -> bool:
+    return get_settings().otel_enabled
+
+
+def _resource(settings: Settings) -> Resource:
+    return Resource.create(
+        {
+            "service.name": settings.otel_service_name,
+            "service.version": settings.otel_service_version,
+        }
+    )
+
+
+def _otlp_endpoint(settings: Settings) -> str:
+    base = (settings.otel_exporter_endpoint or "http://localhost:4318").rstrip("/")
+    return base
+
+
+def setup_telemetry(*, settings: Settings | None = None) -> None:
+    """Idempotent SDK setup. No-op when ``otel_enabled`` is false."""
+    global _initialized, _tracer, _meter
+
+    settings = settings or get_settings()
+    if not settings.otel_enabled:
+        return
+    if _initialized:
+        return
+
+    resource = _resource(settings)
+    endpoint = _otlp_endpoint(settings)
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces"),
+        )
+    )
+    trace.set_tracer_provider(tracer_provider)
+
+    metric_reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics"),
+        export_interval_millis=settings.otel_metric_export_interval_ms,
+    )
+    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+    metrics.set_meter_provider(meter_provider)
+
+    set_global_textmap(TraceContextTextMapPropagator())
+
+    _tracer = trace.get_tracer(settings.otel_service_name)
+    _meter = metrics.get_meter(settings.otel_service_name)
+    _initialized = True
+    logger.info(
+        "otel.initialized",
+        service=settings.otel_service_name,
+        endpoint=endpoint,
+    )
+
+
+def shutdown_telemetry() -> None:
+    """Flush exporters on process exit."""
+    global _initialized, _tracer, _meter
+
+    if not _initialized:
+        return
+
+    tracer_provider = trace.get_tracer_provider()
+    if hasattr(tracer_provider, "shutdown"):
+        tracer_provider.shutdown()  # type: ignore[union-attr]
+
+    meter_provider = metrics.get_meter_provider()
+    if hasattr(meter_provider, "shutdown"):
+        meter_provider.shutdown()  # type: ignore[union-attr]
+
+    _initialized = False
+    _tracer = None
+    _meter = None
+
+
+def get_tracer() -> Tracer:
+    setup_telemetry()
+    return _tracer or trace.get_tracer(get_settings().otel_service_name)
+
+
+def _ensure_red_instruments() -> None:
+    global _http_requests, _http_errors, _http_duration
+    global _worker_jobs, _worker_errors, _worker_duration
+    global _adapter_runs, _adapter_errors, _adapter_duration
+
+    if _meter is None:
+        setup_telemetry()
+    meter = _meter or metrics.get_meter(get_settings().otel_service_name)
+
+    if _http_requests is None:
+        _http_requests = meter.create_counter(
+            "agentflow.http.server.requests",
+            description="HTTP requests (rate)",
+            unit="1",
+        )
+        _http_errors = meter.create_counter(
+            "agentflow.http.server.errors",
+            description="HTTP server errors (5xx and unhandled)",
+            unit="1",
+        )
+        _http_duration = meter.create_histogram(
+            "agentflow.http.server.duration",
+            description="HTTP request duration",
+            unit="s",
+        )
+        _worker_jobs = meter.create_counter(
+            "agentflow.worker.jobs",
+            description="Worker jobs processed (rate)",
+            unit="1",
+        )
+        _worker_errors = meter.create_counter(
+            "agentflow.worker.job.errors",
+            description="Worker job failures before ACK",
+            unit="1",
+        )
+        _worker_duration = meter.create_histogram(
+            "agentflow.worker.job.duration",
+            description="Worker job end-to-end duration",
+            unit="s",
+        )
+        _adapter_runs = meter.create_counter(
+            "agentflow.adapter.runs",
+            description="Adapter run invocations (rate)",
+            unit="1",
+        )
+        _adapter_errors = meter.create_counter(
+            "agentflow.adapter.run.errors",
+            description="Adapter run failures",
+            unit="1",
+        )
+        _adapter_duration = meter.create_histogram(
+            "agentflow.adapter.run.duration",
+            description="Adapter run duration",
+            unit="s",
+        )
+
+
+def capture_trace_context() -> dict[str, str] | None:
+    """Serialize the active span context for cross-process propagation."""
+    if not is_enabled():
+        return None
+    carrier: dict[str, str] = {}
+    inject(carrier)
+    return carrier or None
+
+
+def instrument_fastapi(app: Any) -> None:
+    """Attach FastAPI auto-instrumentation and RED middleware."""
+    if not is_enabled():
+        return
+    setup_telemetry()
+    FastAPIInstrumentor.instrument_app(
+        app,
+        excluded_urls="/v1/health,/",
+        tracer_provider=trace.get_tracer_provider(),
+        meter_provider=metrics.get_meter_provider(),
+    )
+
+
+def record_http_red(
+    *,
+    method: str,
+    route: str,
+    status_code: int,
+    duration_seconds: float,
+) -> None:
+    if not is_enabled():
+        return
+    _ensure_red_instruments()
+    attrs = {
+        "http.method": method,
+        "http.route": route,
+        "http.status_code": status_code,
+    }
+    assert _http_requests is not None
+    assert _http_duration is not None
+    _http_requests.add(1, attributes=attrs)
+    _http_duration.record(duration_seconds, attributes=attrs)
+    if status_code >= 500:
+        assert _http_errors is not None
+        _http_errors.add(1, attributes=attrs)
+
+
+def record_worker_red(
+    *,
+    adapter: str,
+    outcome: str,
+    duration_seconds: float,
+) -> None:
+    if not is_enabled():
+        return
+    _ensure_red_instruments()
+    attrs = {"adapter": adapter, "outcome": outcome}
+    assert _worker_jobs is not None
+    assert _worker_duration is not None
+    _worker_jobs.add(1, attributes=attrs)
+    _worker_duration.record(duration_seconds, attributes=attrs)
+    if outcome == "error":
+        assert _worker_errors is not None
+        _worker_errors.add(1, attributes=attrs)
+
+
+def record_adapter_red(
+    *,
+    adapter: str,
+    outcome: str,
+    duration_seconds: float,
+) -> None:
+    if not is_enabled():
+        return
+    _ensure_red_instruments()
+    attrs = {"adapter": adapter, "outcome": outcome}
+    assert _adapter_runs is not None
+    assert _adapter_duration is not None
+    _adapter_runs.add(1, attributes=attrs)
+    _adapter_duration.record(duration_seconds, attributes=attrs)
+    if outcome == "error":
+        assert _adapter_errors is not None
+        _adapter_errors.add(1, attributes=attrs)
+
+
+@contextmanager
+def span(
+    name: str,
+    *,
+    attributes: Mapping[str, str | int | float | bool] | None = None,
+    kind: SpanKind = SpanKind.INTERNAL,
+    parent_context: Mapping[str, str] | None = None,
+):
+    """Context manager for a traced block with optional remote parent."""
+    if not is_enabled():
+        yield None
+        return
+
+    ctx = extract(parent_context or {}) if parent_context else None
+    tracer = get_tracer()
+    with tracer.start_as_current_span(
+        name,
+        context=ctx,
+        kind=kind,
+        attributes=dict(attributes or {}),
+    ) as otel_span:
+        try:
+            yield otel_span
+        except Exception as exc:
+            if otel_span is not None:
+                otel_span.record_exception(exc)
+                otel_span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+
+
+async def trace_adapter_run(
+    adapter_name: str,
+    run_id: str,
+    coro: Awaitable[Any],
+) -> Any:
+    """Run ``adapter.run`` inside a span with RED metrics."""
+    if not is_enabled():
+        return await coro
+
+    start = time.perf_counter()
+    outcome = "ok"
+    try:
+        with span(
+            "adapter.run",
+            attributes={"adapter": adapter_name, "run.id": run_id},
+            kind=SpanKind.INTERNAL,
+        ):
+            return await coro
+    except Exception:
+        outcome = "error"
+        raise
+    finally:
+        record_adapter_red(
+            adapter=adapter_name,
+            outcome=outcome,
+            duration_seconds=time.perf_counter() - start,
+        )
+
+
+async def trace_worker_job(
+    *,
+    adapter: str,
+    run_id: str,
+    trace_context: Mapping[str, str] | None,
+    coro: Awaitable[Any],
+) -> Any:
+    """Run a leased job inside a consumer span linked to the API trace."""
+    if not is_enabled():
+        return await coro
+
+    start = time.perf_counter()
+    outcome = "ok"
+    try:
+        with span(
+            "worker.process_job",
+            attributes={"adapter": adapter, "run.id": run_id},
+            kind=SpanKind.CONSUMER,
+            parent_context=trace_context,
+        ):
+            return await coro
+    except Exception:
+        outcome = "error"
+        raise
+    finally:
+        record_worker_red(
+            adapter=adapter,
+            outcome=outcome,
+            duration_seconds=time.perf_counter() - start,
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,9 @@ from app.adapters import (  # noqa: F401 -- registers built-in adapters as a sid
     LangGraphAdapter,
 )
 from app.api.v1.router import api_router
+from app.core.http_metrics import RedMetricsMiddleware
 from app.core.logging import get_logger, setup_logging
+from app.core.telemetry import instrument_fastapi, setup_telemetry, shutdown_telemetry
 from app.db.base import Base
 from app.db.session import engine
 from app.events import get_event_bus
@@ -22,6 +24,7 @@ logger = get_logger("app")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    setup_telemetry()
     # Ensure tables exist for SQLite dev mode. In production with Postgres,
     # `alembic upgrade head` is the source of truth.
     async with engine.begin() as conn:
@@ -34,6 +37,7 @@ async def lifespan(app: FastAPI):
     finally:
         await bus.aclose()
         await engine.dispose()
+        shutdown_telemetry()
 
 
 app = FastAPI(
@@ -49,8 +53,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(RedMetricsMiddleware)
 
 app.include_router(api_router)
+instrument_fastapi(app)
 
 
 @app.get("/", include_in_schema=False)

--- a/backend/app/worker/executor.py
+++ b/backend/app/worker/executor.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.adapters import AdapterContext, get_adapter
 from app.core.logging import get_logger
+from app.core.telemetry import trace_adapter_run
 from app.db.session import SessionLocal
 from app.events import EventBus
 from app.models import Agent, RunStatus
@@ -88,7 +89,9 @@ class RunExecutor:
             watcher = asyncio.create_task(self._cancel_watcher(run.id, task))
             try:
                 try:
-                    result = await adapter.run(ctx)
+                    result = await trace_adapter_run(
+                        adapter_name, run_id, adapter.run(ctx)
+                    )
                 except asyncio.CancelledError:
                     # Cancellation may interrupt a flush; clear the session
                     # so the finalising write can proceed.

--- a/backend/app/worker/queue.py
+++ b/backend/app/worker/queue.py
@@ -109,27 +109,47 @@ class RunJob:
     agent_id: str
     adapter: str
     enqueued_at: str
+    trace_context: dict[str, str] | None = None
 
     @classmethod
-    def new(cls, *, run_id: str, agent_id: str, adapter: str) -> RunJob:
+    def new(
+        cls,
+        *,
+        run_id: str,
+        agent_id: str,
+        adapter: str,
+        trace_context: dict[str, str] | None = None,
+    ) -> RunJob:
+        if trace_context is None:
+            from app.core.telemetry import capture_trace_context
+
+            trace_context = capture_trace_context()
         return cls(
             run_id=run_id,
             agent_id=agent_id,
             adapter=adapter,
             enqueued_at=datetime.now(UTC).isoformat(),
+            trace_context=trace_context,
         )
 
     def to_json(self) -> str:
-        return json.dumps(asdict(self))
+        data = asdict(self)
+        if data.get("trace_context") is None:
+            data.pop("trace_context", None)
+        return json.dumps(data)
 
     @classmethod
     def from_json(cls, payload: str) -> RunJob:
         data = json.loads(payload)
+        trace_context = data.get("trace_context")
+        if trace_context is not None and not isinstance(trace_context, dict):
+            trace_context = None
         return cls(
             run_id=data["run_id"],
             agent_id=data["agent_id"],
             adapter=data["adapter"],
             enqueued_at=data.get("enqueued_at", datetime.now(UTC).isoformat()),
+            trace_context=trace_context,
         )
 
 

--- a/backend/app/worker/runner.py
+++ b/backend/app/worker/runner.py
@@ -21,6 +21,7 @@ import signal
 from app.adapters import EchoAdapter, LangGraphAdapter  # noqa: F401 - register
 from app.core.config import get_settings
 from app.core.logging import get_logger, setup_logging
+from app.core.telemetry import setup_telemetry, shutdown_telemetry, trace_worker_job
 from app.db.base import Base
 from app.db.session import engine
 from app.events import get_event_bus
@@ -64,7 +65,12 @@ async def _process_lease(
         deliveries=lease.delivery_count,
     )
     try:
-        await executor.execute(job.run_id, job.adapter)
+        await trace_worker_job(
+            adapter=job.adapter,
+            run_id=job.run_id,
+            trace_context=job.trace_context,
+            coro=executor.execute(job.run_id, job.adapter),
+        )
     except asyncio.CancelledError:
         logger.info("job.cancelled", run_id=job.run_id)
         await queue.ack(lease)
@@ -127,6 +133,7 @@ async def _consume_loop(
 
 async def run_forever() -> None:
     setup_logging()
+    setup_telemetry()
     settings = get_settings()
     concurrency = settings.worker_concurrency
     logger.info("worker.starting", concurrency=concurrency)
@@ -173,6 +180,7 @@ async def run_forever() -> None:
         await cancel_registry.aclose()
         await bus.aclose()
         await engine.dispose()
+        shutdown_telemetry()
 
 
 def main() -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     "python-ulid>=3.0",
     "langgraph>=0.2.50",
     "langchain-core>=0.3",
+    "opentelemetry-api>=1.28",
+    "opentelemetry-sdk>=1.28",
+    "opentelemetry-exporter-otlp-proto-http>=1.28",
+    "opentelemetry-instrumentation-fastapi>=0.49b0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -1,0 +1,58 @@
+"""OpenTelemetry bootstrap and trace propagation on run jobs."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.core.config import Settings
+from app.core.telemetry import (
+    capture_trace_context,
+    is_enabled,
+    setup_telemetry,
+    shutdown_telemetry,
+)
+from app.worker.queue import RunJob
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel():
+    shutdown_telemetry()
+    yield
+    shutdown_telemetry()
+
+
+def test_otel_disabled_by_default():
+    assert not is_enabled()
+    assert capture_trace_context() is None
+
+
+def test_setup_telemetry_noop_when_disabled():
+    setup_telemetry(settings=Settings(otel_enabled=False))
+    assert capture_trace_context() is None
+
+
+def test_runjob_trace_context_round_trip():
+    ctx = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}
+    job = RunJob.new(
+        run_id="r1",
+        agent_id="a1",
+        adapter="echo",
+        trace_context=ctx,
+    )
+    payload = job.to_json()
+    assert "trace_context" in payload
+    restored = RunJob.from_json(payload)
+    assert restored.trace_context == ctx
+
+
+def test_runjob_omits_empty_trace_context():
+    job = RunJob.new(
+        run_id="r1",
+        agent_id="a1",
+        adapter="echo",
+        trace_context=None,
+    )
+    data = json.loads(job.to_json())
+    assert "trace_context" not in data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,23 @@ services:
       AGENTFLOW_REDIS_URL: redis://redis:6379/0
       AGENTFLOW_WORKER_MODE: queue
       AGENTFLOW_LOG_LEVEL: INFO
+      AGENTFLOW_OTEL_ENABLED: ${AGENTFLOW_OTEL_ENABLED:-false}
+      AGENTFLOW_OTEL_EXPORTER_ENDPOINT: ${AGENTFLOW_OTEL_EXPORTER_ENDPOINT:-http://otel-collector:4318}
+      AGENTFLOW_OTEL_SERVICE_NAME: agentflow-worker
     profiles:
       - app
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.96.0
+    container_name: agentflow-otel
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./docker/otel-collector.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4318:4318"
+      - "8889:8889"
+    profiles:
+      - observability
 
   api:
     build: ./backend-java
@@ -59,6 +74,10 @@ services:
       AGENTFLOW_REDIS_HOST: redis
       AGENTFLOW_REDIS_PORT: "6379"
       AGENTFLOW_SERVER_PORT: "8000"
+      AGENTFLOW_OTEL_ENABLED: ${AGENTFLOW_OTEL_ENABLED:-false}
+      AGENTFLOW_OTEL_EXPORTER_ENDPOINT: ${AGENTFLOW_OTEL_EXPORTER_ENDPOINT:-http://otel-collector:4318/v1/traces}
+      AGENTFLOW_OTEL_METRICS_ENDPOINT: ${AGENTFLOW_OTEL_METRICS_ENDPOINT:-http://otel-collector:4318/v1/metrics}
+      AGENTFLOW_OTEL_SERVICE_NAME: agentflow-api
     ports:
       - "8000:8000"
     healthcheck:

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -1,0 +1,26 @@
+# Local OTLP receiver for API + worker traces and RED metrics.
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: basic
+  prometheus:
+    endpoint: 0.0.0.0:8889
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, debug]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,6 +49,28 @@ cd backend && uv run alembic upgrade head
 Optional model-provider keys (`AGENTFLOW_OPENAI_API_KEY`, etc.) are only
 needed when running adapters that call external models.
 
+### OpenTelemetry (optional)
+
+| Variable | Component | Description |
+| --- | --- | --- |
+| `AGENTFLOW_OTEL_ENABLED` | API + worker | `true` to export traces and RED metrics via OTLP |
+| `AGENTFLOW_OTEL_SERVICE_NAME` | API + worker | `service.name` (defaults: `agentflow-api`, `agentflow-worker`) |
+| `AGENTFLOW_OTEL_EXPORTER_ENDPOINT` | API | OTLP HTTP traces URL (default `http://localhost:4318/v1/traces`) |
+| `AGENTFLOW_OTEL_METRICS_ENDPOINT` | API | OTLP HTTP metrics URL (default `http://localhost:4318/v1/metrics`) |
+| `AGENTFLOW_OTEL_EXPORTER_ENDPOINT` | Worker | OTLP HTTP base URL without path (default `http://localhost:4318`) |
+
+RED metric names (both stacks): `agentflow.http.server.*`, `agentflow.worker.job.*`,
+`agentflow.adapter.run.*`. Run jobs carry W3C `trace_context` in the Redis payload so
+worker spans link to the API trace.
+
+Local collector + Prometheus scrape:
+
+```bash
+docker compose --profile observability --profile app up --build
+# OTLP HTTP :4318, Prometheus exporter :8889
+export AGENTFLOW_OTEL_ENABLED=true
+```
+
 ### Frontend
 
 | Variable | Production value |

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -46,7 +46,7 @@
 - [ ] Adapter 写入 token/成本；Run 级汇总
 - [ ] `POST /v1/runs/{id}/retry` 与 `POST /v1/runs/{id}/resume`
 - [ ] SSE 事件重放（`Last-Event-ID`）
-- [ ] OpenTelemetry 全链路 trace
+- [x] OpenTelemetry 全链路 trace（API → worker → adapter，RED 指标 + trace 传播）
 - [ ] 队列深度、worker 利用率、p95 耗时等指标
 - [x] Compose 集成测试与 CI（`integration` job）
 


### PR DESCRIPTION
- Added OpenTelemetry support for distributed tracing and RED metrics in both API and worker components.
- Configured environment variables for enabling OpenTelemetry and specifying service names and exporter endpoints.
- Implemented middleware for HTTP request metrics and integrated tracing into job processing.
- Updated the Docker Compose configuration to include an OpenTelemetry collector service.
- Enhanced the backend with new telemetry utilities and tests to validate trace context propagation.
- Updated documentation to include OpenTelemetry setup instructions and environment variable details.