### PR TITLE
Feature

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package io.agentflow.api.controller;
 
 import io.agentflow.api.service.AgentNameConflictException;
 import io.agentflow.api.service.AgentNotFoundException;
+import io.agentflow.api.service.RunConflictException;
 import io.agentflow.api.service.RunNotFoundException;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -27,7 +28,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(AgentNameConflictException.class)
-    public ResponseEntity<Map<String, String>> handleConflict(AgentNameConflictException ex) {
+    public ResponseEntity<Map<String, String>> handleAgentNameConflict(AgentNameConflictException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("detail", ex.getMessage()));
+    }
+
+    @ExceptionHandler(RunConflictException.class)
+    public ResponseEntity<Map<String, String>> handleRunConflict(RunConflictException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("detail", ex.getMessage()));
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/controller/RunsController.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/RunsController.java
@@ -2,6 +2,8 @@ package io.agentflow.api.controller;
 
 import io.agentflow.api.dto.RunCreateRequest;
 import io.agentflow.api.dto.RunResponse;
+import io.agentflow.api.dto.RunResumeRequest;
+import io.agentflow.api.dto.RunRetryRequest;
 import io.agentflow.api.service.RunService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -45,5 +47,19 @@ public class RunsController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void cancel(@PathVariable String id) {
         service.cancel(id);
+    }
+
+    @PostMapping("/{id}/retry")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public RunResponse retry(
+            @PathVariable String id, @RequestBody(required = false) RunRetryRequest payload) {
+        return service.retry(id, payload);
+    }
+
+    @PostMapping("/{id}/resume")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public RunResponse resume(
+            @PathVariable String id, @RequestBody(required = false) RunResumeRequest payload) {
+        return service.resume(id, payload);
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/dto/RunResumeRequest.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunResumeRequest.java
@@ -1,0 +1,17 @@
+package io.agentflow.api.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RunResumeRequest {
+
+    private Map<String, Object> input = new HashMap<>();
+
+    public Map<String, Object> getInput() {
+        return input;
+    }
+
+    public void setInput(Map<String, Object> input) {
+        this.input = input == null ? new HashMap<>() : input;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/RunRetryRequest.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunRetryRequest.java
@@ -1,0 +1,14 @@
+package io.agentflow.api.dto;
+
+public class RunRetryRequest {
+
+    private Integer checkpointIndex;
+
+    public Integer getCheckpointIndex() {
+        return checkpointIndex;
+    }
+
+    public void setCheckpointIndex(Integer checkpointIndex) {
+        this.checkpointIndex = checkpointIndex;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/ResumeMetadata.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/ResumeMetadata.java
@@ -1,0 +1,57 @@
+package io.agentflow.api.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Mirrors {@code app.runtime.resume_context} on the Python worker. */
+final class ResumeMetadata {
+
+    static final String RESUME_META_KEY = "_resume";
+
+    private ResumeMetadata() {}
+
+    static Map<String, Object> retry(
+            Map<String, Object> checkpointState, Integer checkpointIndex) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("mode", "retry");
+        if (checkpointState != null) {
+            payload.put("checkpoint_state", checkpointState);
+        }
+        if (checkpointIndex != null) {
+            payload.put("checkpoint_index", checkpointIndex);
+        }
+        return Map.of(RESUME_META_KEY, payload);
+    }
+
+    static Map<String, Object> resume(
+            Map<String, Object> checkpointState,
+            Integer checkpointIndex,
+            Map<String, Object> humanInput) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("mode", "resume");
+        if (checkpointState != null) {
+            payload.put("checkpoint_state", checkpointState);
+        }
+        if (checkpointIndex != null) {
+            payload.put("checkpoint_index", checkpointIndex);
+        }
+        if (humanInput != null && !humanInput.isEmpty()) {
+            payload.put("human_input", humanInput);
+        }
+        return Map.of(RESUME_META_KEY, payload);
+    }
+
+    static Map<String, Object> withoutResume(Map<String, Object> metadata) {
+        if (metadata == null || !metadata.containsKey(RESUME_META_KEY)) {
+            return metadata == null ? new HashMap<>() : new HashMap<>(metadata);
+        }
+        Map<String, Object> cleaned = new HashMap<>(metadata);
+        cleaned.remove(RESUME_META_KEY);
+        return cleaned;
+    }
+
+    static void mergeInto(Map<String, Object> metadata, Map<String, Object> resumeBlock) {
+        metadata.putAll(withoutResume(metadata));
+        metadata.putAll(resumeBlock);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RunConflictException.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunConflictException.java
@@ -1,0 +1,8 @@
+package io.agentflow.api.service;
+
+public class RunConflictException extends RuntimeException {
+
+    public RunConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RunService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunService.java
@@ -4,6 +4,9 @@ import io.agentflow.api.dto.CheckpointResponse;
 import io.agentflow.api.dto.MessageResponse;
 import io.agentflow.api.dto.RunCreateRequest;
 import io.agentflow.api.dto.RunResponse;
+import io.agentflow.api.dto.RunResumeRequest;
+import io.agentflow.api.dto.RunRetryRequest;
+import io.agentflow.api.entity.CheckpointEntity;
 import io.agentflow.api.dto.StepResponse;
 import io.agentflow.api.dto.ToolCallResponse;
 import io.agentflow.api.entity.AgentEntity;
@@ -105,6 +108,79 @@ public class RunService {
         cancelSignal.requestCancel(run.getId());
         // We do not flip the row to CANCELLED here: the worker owns the
         // transition so steps/messages can be flushed first.
+    }
+
+    @Transactional
+    public RunResponse retry(String id, RunRetryRequest req) {
+        RunEntity run = runs.findById(id).orElseThrow(() -> new RunNotFoundException(id));
+        if (run.getStatus() != RunStatus.FAILED) {
+            throw new RunConflictException(
+                    "Cannot retry run " + id + " in status " + run.getStatus().wire());
+        }
+
+        List<CheckpointEntity> cps = checkpoints.findAllByRunIdOrderByIndexAsc(run.getId());
+        Map<String, Object> checkpointState = null;
+        Integer checkpointIndex = null;
+        if (!cps.isEmpty()) {
+            Integer requested = req != null ? req.getCheckpointIndex() : null;
+            CheckpointEntity chosen;
+            if (requested != null) {
+                chosen = cps.stream()
+                        .filter(cp -> cp.getIndex() == requested)
+                        .findFirst()
+                        .orElseThrow(() -> new RunConflictException(
+                                "Cannot retry run " + id + " (checkpoint " + requested + " missing)"));
+            } else {
+                chosen = cps.get(cps.size() - 1);
+            }
+            checkpointState = chosen.getState();
+            checkpointIndex = chosen.getIndex();
+        }
+
+        Map<String, Object> meta = ResumeMetadata.withoutResume(run.getMetadata());
+        ResumeMetadata.mergeInto(
+                meta, ResumeMetadata.retry(checkpointState, checkpointIndex));
+        run.setStatus(RunStatus.PENDING);
+        run.setError(null);
+        run.setMetadata(meta);
+        RunEntity saved = runs.save(run);
+        enqueueJobAfterCommit(saved.getId(), saved.getAgentId(), saved.getAdapter());
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public RunResponse resume(String id, RunResumeRequest req) {
+        RunEntity run = runs.findById(id).orElseThrow(() -> new RunNotFoundException(id));
+        if (run.getStatus() != RunStatus.WAITING_HUMAN) {
+            throw new RunConflictException(
+                    "Cannot resume run " + id + " in status " + run.getStatus().wire());
+        }
+
+        Map<String, Object> humanInput =
+                req != null && req.getInput() != null ? req.getInput() : Map.of();
+        if (!humanInput.isEmpty()) {
+            Map<String, Object> merged = new HashMap<>(run.getInput());
+            merged.putAll(humanInput);
+            run.setInput(merged);
+        }
+
+        List<CheckpointEntity> cps = checkpoints.findAllByRunIdOrderByIndexAsc(run.getId());
+        Map<String, Object> checkpointState = null;
+        Integer checkpointIndex = null;
+        if (!cps.isEmpty()) {
+            CheckpointEntity latest = cps.get(cps.size() - 1);
+            checkpointState = latest.getState();
+            checkpointIndex = latest.getIndex();
+        }
+
+        Map<String, Object> meta = ResumeMetadata.withoutResume(run.getMetadata());
+        ResumeMetadata.mergeInto(
+                meta, ResumeMetadata.resume(checkpointState, checkpointIndex, humanInput));
+        run.setStatus(RunStatus.PENDING);
+        run.setMetadata(meta);
+        RunEntity saved = runs.save(run);
+        enqueueJobAfterCommit(saved.getId(), saved.getAgentId(), saved.getAdapter());
+        return toResponse(saved);
     }
 
     /**

--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from app.models.run import RunStatus
 from app.schemas.run import EventType
+from app.runtime.resume_context import RunResumeContext
 
 EmitCallback = Callable[[EventType, dict[str, Any]], Awaitable[None]]
 
@@ -34,6 +35,8 @@ class AdapterContext:
     agent_config: dict[str, Any]
     input: dict[str, Any]
     metadata: dict[str, Any] = field(default_factory=dict)
+    resume: RunResumeContext | None = None
+    step_index_base: int = 0
     emit: EmitCallback = field(
         default=None  # type: ignore[assignment]
     )
@@ -129,6 +132,19 @@ class AdapterContext:
             {"message": message, "at": datetime.now(UTC).isoformat(), **fields},
         )
 
+    async def emit_checkpoint(
+        self,
+        *,
+        state: dict[str, Any],
+        label: str | None = None,
+        **data: Any,
+    ) -> None:
+        """Persist an adapter-defined snapshot for retry / resume."""
+        await self.emit(
+            "checkpoint.created",
+            {"label": label, "state": state, **data},
+        )
+
 
 @dataclass
 class AdapterResult:
@@ -156,6 +172,22 @@ class OrchestratorAdapter(ABC):
           than letting exceptions escape (the runtime will still convert
           uncaught exceptions, but explicit returns produce nicer audit logs).
         """
+
+    async def retry(self, ctx: AdapterContext) -> AdapterResult:
+        """Re-execute after failure, usually from a checkpoint.
+
+        Override when retry semantics differ from a fresh run. The default
+        delegates to ``run``; read ``ctx.resume`` for checkpoint state.
+        """
+        return await self.run(ctx)
+
+    async def resume(self, ctx: AdapterContext) -> AdapterResult:
+        """Continue after ``waiting_human``.
+
+        Override to merge ``ctx.resume.human_input`` into graph state. The
+        default delegates to ``run``.
+        """
+        return await self.run(ctx)
 
 
 _registry: dict[str, OrchestratorAdapter] = {}

--- a/backend/app/adapters/echo_adapter.py
+++ b/backend/app/adapters/echo_adapter.py
@@ -2,6 +2,13 @@
 
 It walks through a tiny three-step program and emits the same events any
 real adapter would emit. There is no LLM call, no network IO, no extra deps.
+
+Agent config knobs for retry / resume demos:
+
+- ``fail_at_node``: ``"tool"`` — fail on first attempt at the tool step;
+  succeeds on ``retry`` when a checkpoint exists.
+- ``pause_before_reply``: ``true`` — stop in ``waiting_human`` after the tool
+  step; ``resume`` continues from the saved checkpoint.
 """
 
 from __future__ import annotations
@@ -11,6 +18,28 @@ from typing import Any
 
 from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
 from app.models.run import RunStatus
+_STEPS = ("plan", "tool", "reply")
+
+
+def _start_step_index(ctx: AdapterContext) -> int:
+    if ctx.resume and ctx.resume.checkpoint_state:
+        raw = ctx.resume.checkpoint_state.get("next_step_index", 0)
+        try:
+            return max(0, min(int(raw), len(_STEPS) - 1))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def _step_index(ctx: AdapterContext, logical: int, start_logical: int) -> int:
+    return ctx.step_index_base + (logical - start_logical)
+
+
+async def _checkpoint_after(ctx: AdapterContext, next_step_index: int) -> None:
+    await ctx.emit_checkpoint(
+        label=_STEPS[next_step_index - 1] if next_step_index > 0 else "start",
+        state={"next_step_index": next_step_index},
+    )
 
 
 class EchoAdapter(OrchestratorAdapter):
@@ -19,31 +48,65 @@ class EchoAdapter(OrchestratorAdapter):
     async def run(self, ctx: AdapterContext) -> AdapterResult:
         delay: float = float(ctx.agent_config.get("delay", 0.05))
         prompt: Any = ctx.input.get("prompt", "")
+        fail_at: str | None = ctx.agent_config.get("fail_at_node")
+        pause_before_reply = bool(ctx.agent_config.get("pause_before_reply"))
+        start = _start_step_index(ctx)
+        is_retry = ctx.resume is not None and ctx.resume.mode == "retry"
 
-        await ctx.emit_step_started(index=0, node="plan")
-        await ctx.emit_message(role="user", content=str(prompt))
-        await asyncio.sleep(delay)
-        await ctx.emit_step_completed(
-            index=0, node="plan", output={"plan": ["greet", "respond"]}
-        )
+        if start <= 0:
+            idx = _step_index(ctx, 0, start)
+            await ctx.emit_step_started(index=idx, node="plan")
+            await ctx.emit_message(role="user", content=str(prompt))
+            await asyncio.sleep(delay)
+            await ctx.emit_step_completed(
+                index=idx, node="plan", output={"plan": ["greet", "respond"]}
+            )
+            await _checkpoint_after(ctx, 1)
 
-        await ctx.emit_step_started(index=1, node="tool")
-        await ctx.emit_tool_call_started(
-            step_index=1, name="echo", arguments={"text": prompt}
-        )
-        await asyncio.sleep(delay)
-        await ctx.emit_tool_call_completed(
-            step_index=1, name="echo", result={"text": prompt}
-        )
-        await ctx.emit_step_completed(
-            index=1, node="tool", output={"echo": prompt}
-        )
+        if start <= 1:
+            idx = _step_index(ctx, 1, start)
+            if fail_at == "tool" and not is_retry:
+                await ctx.emit_step_started(index=idx, node="tool")
+                await ctx.emit_step_failed(
+                    index=idx, node="tool", error="simulated tool failure"
+                )
+                return AdapterResult(
+                    status=RunStatus.FAILED,
+                    error="simulated tool failure",
+                )
+
+            await ctx.emit_step_started(index=idx, node="tool")
+            await ctx.emit_tool_call_started(
+                step_index=idx, name="echo", arguments={"text": prompt}
+            )
+            await asyncio.sleep(delay)
+            await ctx.emit_tool_call_completed(
+                step_index=idx, name="echo", result={"text": prompt}
+            )
+            await ctx.emit_step_completed(
+                index=idx, node="tool", output={"echo": prompt}
+            )
+            await _checkpoint_after(ctx, 2)
+
+            if pause_before_reply and not (
+                ctx.resume and ctx.resume.mode == "resume"
+            ):
+                return AdapterResult(
+                    status=RunStatus.WAITING_HUMAN,
+                    output={"awaiting": "human approval before reply"},
+                )
 
         reply = f"echo: {prompt}"
-        await ctx.emit_step_started(index=2, node="reply")
+        if ctx.resume and ctx.resume.mode == "resume" and ctx.resume.human_input:
+            approval = ctx.resume.human_input.get("approval", "")
+            if approval:
+                reply = f"{reply} ({approval})"
+
+        idx = _step_index(ctx, 2, start)
+        await ctx.emit_step_started(index=idx, node="reply")
         await ctx.emit_message(role="assistant", content=reply)
         await ctx.emit_step_completed(
-            index=2, node="reply", output={"reply": reply}
+            index=idx, node="reply", output={"reply": reply}
         )
 
         return AdapterResult(status=RunStatus.SUCCEEDED, output={"reply": reply})

--- a/backend/app/adapters/langgraph_adapter.py
+++ b/backend/app/adapters/langgraph_adapter.py
@@ -198,12 +198,9 @@ class LangGraphAdapter(OrchestratorAdapter):
             graph.add_edge(src, dst)
 
         compiled = graph.compile()
-        initial = {
-            "input": ctx.input.get("prompt", ""),
-            "messages": [],
-            "reply": None,
-            "tool_results": {},
-        }
+        initial = _initial_graph_state(ctx)
+        if ctx.resume and ctx.resume.mode == "resume" and ctx.resume.human_input:
+            initial = {**initial, **ctx.resume.human_input}
 
         try:
             final_state = await compiled.ainvoke(initial)
@@ -266,7 +263,15 @@ class LangGraphAdapter(OrchestratorAdapter):
                 )
                 tool_results = dict(state.get("tool_results") or {})
                 tool_results[tool_def.name] = result
-                return {"tool_results": tool_results, "reply": str(result)}
+                next_state = {
+                    "tool_results": tool_results,
+                    "reply": str(result),
+                }
+                await ctx.emit_checkpoint(
+                    label=spec.id,
+                    state={"graph_state": {**state, **next_state}},
+                )
+                return next_state
             except Exception as exc:
                 await ctx.emit_tool_call_completed(
                     step_index=step_idx,
@@ -339,7 +344,12 @@ class LangGraphAdapter(OrchestratorAdapter):
                     {"role": "assistant", "content": reply},
                 ]
             )
-            return {"reply": reply, "messages": messages}
+            next_state = {"reply": reply, "messages": messages}
+            await ctx.emit_checkpoint(
+                label=spec.id,
+                state={"graph_state": {**state, **next_state}},
+            )
+            return next_state
 
         return handler
 
@@ -496,6 +506,20 @@ def _estimate_tokens(text: str) -> int:
     if not text:
         return 0
     return max(1, len(text) // 4)
+
+
+def _initial_graph_state(ctx: AdapterContext) -> dict[str, Any]:
+    default = {
+        "input": ctx.input.get("prompt", ""),
+        "messages": [],
+        "reply": None,
+        "tool_results": {},
+    }
+    if ctx.resume and ctx.resume.checkpoint_state:
+        saved = ctx.resume.checkpoint_state.get("graph_state")
+        if isinstance(saved, dict):
+            return {**default, **saved}
+    return default
 
 
 def _chunk_text(text: str, *, size: int = 8) -> list[str]:

--- a/backend/app/api/v1/runs.py
+++ b/backend/app/api/v1/runs.py
@@ -3,9 +3,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.events import EventBus, get_event_bus
-from app.schemas.run import RunCreate, RunRead
+from app.schemas.run import RunCreate, RunRead, RunResume, RunRetry
 from app.services.run_service import (
     AgentNotFound,
+    RunConflict,
     RunNotFound,
     RunService,
 )
@@ -61,3 +62,33 @@ async def cancel_run(
         await service.cancel_run(run_id)
     except RunNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
+
+
+@router.post("/{run_id}/retry", response_model=RunRead, status_code=status.HTTP_202_ACCEPTED)
+async def retry_run(
+    run_id: str,
+    payload: RunRetry | None = None,
+    service: RunService = Depends(get_run_service),
+) -> RunRead:
+    try:
+        run = await service.retry_run(run_id, payload)
+    except RunNotFound as exc:
+        raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
+    except RunConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return RunRead.model_validate(run)
+
+
+@router.post("/{run_id}/resume", response_model=RunRead, status_code=status.HTTP_202_ACCEPTED)
+async def resume_run(
+    run_id: str,
+    payload: RunResume | None = None,
+    service: RunService = Depends(get_run_service),
+) -> RunRead:
+    try:
+        run = await service.resume_run(run_id, payload)
+    except RunNotFound as exc:
+        raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
+    except RunConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return RunRead.model_validate(run)

--- a/backend/app/runtime/resume_context.py
+++ b/backend/app/runtime/resume_context.py
@@ -1,0 +1,72 @@
+"""Resume / retry metadata passed from the API into the worker executor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+RESUME_META_KEY = "_resume"
+
+
+@dataclass(frozen=True)
+class RunResumeContext:
+    """Adapter-facing resume instructions for a single execution attempt."""
+
+    mode: Literal["retry", "resume"]
+    checkpoint_state: dict[str, Any] | None = None
+    checkpoint_index: int | None = None
+    human_input: dict[str, Any] | None = None
+
+
+def resume_metadata(
+    *,
+    mode: Literal["retry", "resume"],
+    checkpoint_state: dict[str, Any] | None = None,
+    checkpoint_index: int | None = None,
+    human_input: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"mode": mode}
+    if checkpoint_state is not None:
+        payload["checkpoint_state"] = checkpoint_state
+    if checkpoint_index is not None:
+        payload["checkpoint_index"] = checkpoint_index
+    if human_input is not None:
+        payload["human_input"] = human_input
+    return {RESUME_META_KEY: payload}
+
+
+def parse_resume_context(metadata: dict[str, Any] | None) -> RunResumeContext | None:
+    if not metadata:
+        return None
+    raw = metadata.get(RESUME_META_KEY)
+    if not isinstance(raw, dict):
+        return None
+    mode = raw.get("mode")
+    if mode not in ("retry", "resume"):
+        return None
+    checkpoint_state = raw.get("checkpoint_state")
+    if checkpoint_state is not None and not isinstance(checkpoint_state, dict):
+        checkpoint_state = None
+    human_input = raw.get("human_input")
+    if human_input is not None and not isinstance(human_input, dict):
+        human_input = None
+    checkpoint_index = raw.get("checkpoint_index")
+    if checkpoint_index is not None:
+        try:
+            checkpoint_index = int(checkpoint_index)
+        except (TypeError, ValueError):
+            checkpoint_index = None
+    return RunResumeContext(
+        mode=mode,
+        checkpoint_state=checkpoint_state,
+        checkpoint_index=checkpoint_index,
+        human_input=human_input,
+    )
+
+
+def without_resume_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    if RESUME_META_KEY not in metadata:
+        return metadata
+    cleaned = dict(metadata)
+    cleaned.pop(RESUME_META_KEY, None)
+    return cleaned

--- a/backend/app/schemas/run.py
+++ b/backend/app/schemas/run.py
@@ -16,6 +16,20 @@ class RunCreate(BaseModel):
     )
 
 
+class RunRetry(BaseModel):
+    checkpoint_index: int | None = Field(
+        default=None,
+        description="Resume from this checkpoint; latest when omitted.",
+    )
+
+
+class RunResume(BaseModel):
+    input: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Human approval payload merged into the run input.",
+    )
+
+
 class ToolCallRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -90,6 +104,7 @@ EventType = Literal[
     "run.completed",
     "run.failed",
     "run.cancelled",
+    "run.waiting_human",
     "step.started",
     "step.updated",
     "step.completed",

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -30,7 +30,13 @@ from app.models import (
     Step,
     ToolCall,
 )
-from app.schemas.run import EventType, RunCreate, RunEvent
+from app.schemas.run import EventType, RunCreate, RunEvent, RunResume, RunRetry
+from app.runtime.resume_context import (
+    RunResumeContext,
+    parse_resume_context,
+    resume_metadata,
+    without_resume_metadata,
+)
 from app.worker.cancel import CancelRegistry, get_cancel_registry
 from app.worker.queue import JobQueue, RunJob, get_job_queue
 
@@ -43,6 +49,17 @@ class RunNotFound(Exception):
 
 class AgentNotFound(Exception):
     pass
+
+
+class RunConflict(Exception):
+    """Run status does not allow the requested control action."""
+
+    def __init__(self, run_id: str, status: RunStatus, action: str) -> None:
+        self.run_id = run_id
+        self.status = status
+        self.action = action
+        label = status.value if isinstance(status, RunStatus) else str(status)
+        super().__init__(f"Cannot {action} run {run_id} in status {label}")
 
 
 # Tasks survive beyond a single request, so they are tracked at module scope.
@@ -139,6 +156,83 @@ class RunService:
         finally:
             _running_tasks.pop(run_id, None)
 
+    async def retry_run(self, run_id: str, payload: RunRetry | None = None) -> Run:
+        """Re-queue a failed run, optionally from a checkpoint snapshot."""
+        run = await self._get_run(run_id, with_relations=True)
+        if run.status != RunStatus.FAILED:
+            raise RunConflict(run_id, run.status, "retry")
+
+        checkpoint_state: dict[str, Any] | None = None
+        checkpoint_index: int | None = None
+        if run.checkpoints:
+            req_index = payload.checkpoint_index if payload else None
+            if req_index is not None:
+                match = next(
+                    (cp for cp in run.checkpoints if cp.index == req_index),
+                    None,
+                )
+                if match is None:
+                    raise RunConflict(
+                        run_id, run.status, f"retry (checkpoint {req_index} missing)"
+                    )
+                checkpoint_state = match.state
+                checkpoint_index = match.index
+            else:
+                latest = run.checkpoints[-1]
+                checkpoint_state = latest.state
+                checkpoint_index = latest.index
+
+        meta = without_resume_metadata(dict(run.metadata_ or {}))
+        meta.update(
+            resume_metadata(
+                mode="retry",
+                checkpoint_state=checkpoint_state,
+                checkpoint_index=checkpoint_index,
+            )
+        )
+        run.status = RunStatus.PENDING
+        run.error = None
+        run.metadata_ = meta
+        await self.session.commit()
+
+        await self.start_run(run_id)
+        return await self.get_run(run_id, with_relations=True)
+
+    async def resume_run(self, run_id: str, payload: RunResume | None = None) -> Run:
+        """Continue a run paused for human approval."""
+        run = await self._get_run(run_id, with_relations=True)
+        if run.status != RunStatus.WAITING_HUMAN:
+            raise RunConflict(run_id, run.status, "resume")
+
+        human_input = (payload.input if payload else {}) or {}
+        if human_input:
+            merged = dict(run.input or {})
+            merged.update(human_input)
+            run.input = merged
+
+        checkpoint_state: dict[str, Any] | None = None
+        checkpoint_index: int | None = None
+        if run.checkpoints:
+            latest = run.checkpoints[-1]
+            checkpoint_state = latest.state
+            checkpoint_index = latest.index
+
+        meta = without_resume_metadata(dict(run.metadata_ or {}))
+        meta.update(
+            resume_metadata(
+                mode="resume",
+                checkpoint_state=checkpoint_state,
+                checkpoint_index=checkpoint_index,
+                human_input=human_input or None,
+            )
+        )
+        run.status = RunStatus.PENDING
+        run.metadata_ = meta
+        await self.session.commit()
+
+        await self.start_run(run_id)
+        return await self.get_run(run_id, with_relations=True)
+
     async def cancel_run(self, run_id: str) -> None:
         # Ensure the run exists so the API returns 404 for unknown ids
         # whether or not a worker is currently executing it.
@@ -203,6 +297,12 @@ class RunService:
             await self._broadcast("run.failed", run_id, {"error": error})
         elif status == RunStatus.CANCELLED:
             await self._broadcast("run.cancelled", run_id, {"error": error})
+        elif status == RunStatus.WAITING_HUMAN:
+            await self._broadcast(
+                "run.waiting_human",
+                run_id,
+                {"output": output},
+            )
 
     async def _broadcast(
         self, event_type: EventType, run_id: str, data: dict[str, Any]
@@ -312,6 +412,17 @@ class RunService:
             await self.session.commit()
 
         await self._broadcast(event_type, run_id, data)
+
+    async def _max_step_index(self, run_id: str) -> int:
+        stmt = (
+            select(Step.index)
+            .where(Step.run_id == run_id)
+            .order_by(Step.index.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        last = result.scalar_one_or_none()
+        return -1 if last is None else last
 
     async def _find_step(self, run_id: str, index: int) -> Step | None:
         stmt = select(Step).where(Step.run_id == run_id, Step.index == index)

--- a/backend/app/worker/executor.py
+++ b/backend/app/worker/executor.py
@@ -21,7 +21,16 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from app.adapters import AdapterContext, get_adapter
+from app.adapters.base import (
+    AdapterContext,
+    AdapterResult,
+    OrchestratorAdapter,
+    get_adapter,
+)
+from app.runtime.resume_context import (
+    parse_resume_context,
+    without_resume_metadata,
+)
 from app.core.logging import get_logger
 from app.db.session import SessionLocal
 from app.events import EventBus
@@ -68,6 +77,14 @@ class RunExecutor:
                 await self._safe_clear_cancel(run_id)
                 return
 
+            resume_ctx = parse_resume_context(run.metadata_)
+            if resume_ctx is not None:
+                run.metadata_ = without_resume_metadata(dict(run.metadata_ or {}))
+
+            step_index_base = 0
+            if resume_ctx is not None and resume_ctx.mode in ("retry", "resume"):
+                step_index_base = (await service._max_step_index(run.id)) + 1
+
             run.status = RunStatus.RUNNING
             await session.commit()
             await service._broadcast("run.started", run.id, {})
@@ -78,6 +95,8 @@ class RunExecutor:
                 agent_config=agent.config or {},
                 input=run.input,
                 metadata=run.metadata_,
+                resume=resume_ctx,
+                step_index_base=step_index_base,
                 emit=lambda event_type, data: service._handle_event(
                     run.id, event_type, data
                 ),
@@ -88,7 +107,7 @@ class RunExecutor:
             watcher = asyncio.create_task(self._cancel_watcher(run.id, task))
             try:
                 try:
-                    result = await adapter.run(ctx)
+                    result = await self._invoke_adapter(adapter, ctx, resume_ctx)
                 except asyncio.CancelledError:
                     # Cancellation may interrupt a flush; clear the session
                     # so the finalising write can proceed.
@@ -131,6 +150,21 @@ class RunExecutor:
                 await asyncio.sleep(0.25)
         except asyncio.CancelledError:
             pass
+
+    async def _invoke_adapter(
+        self,
+        adapter: OrchestratorAdapter,
+        ctx: AdapterContext,
+        resume_ctx: object,
+    ) -> AdapterResult:
+        from app.runtime.resume_context import RunResumeContext
+
+        if isinstance(resume_ctx, RunResumeContext):
+            if resume_ctx.mode == "retry":
+                return await adapter.retry(ctx)
+            if resume_ctx.mode == "resume":
+                return await adapter.resume(ctx)
+        return await adapter.run(ctx)
 
     async def _safe_clear_cancel(self, run_id: str) -> None:
         try:

--- a/backend/tests/test_runs.py
+++ b/backend/tests/test_runs.py
@@ -33,3 +33,95 @@ async def test_echo_run_end_to_end(client):
     assert len(body["steps"]) == 3
     assert {step["node"] for step in body["steps"]} == {"plan", "tool", "reply"}
     assert any(msg["role"] == "assistant" for msg in body["messages"])
+
+
+async def _poll_until(client, run_id: str, statuses: set[str], *, attempts: int = 80):
+    body: dict = {}
+    for _ in range(attempts):
+        detail = await client.get(f"/v1/runs/{run_id}")
+        body = detail.json()
+        if body["status"] in statuses:
+            return body
+        await asyncio.sleep(0.05)
+    return body
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_run_from_checkpoint(client):
+    create = await client.post(
+        "/v1/agents",
+        json={
+            "name": "retry-bot",
+            "adapter": "echo",
+            "config": {"delay": 0, "fail_at_node": "tool"},
+        },
+    )
+    agent_id = create.json()["id"]
+
+    run_response = await client.post(
+        "/v1/runs",
+        json={"agent_id": agent_id, "input": {"prompt": "retry-me"}},
+    )
+    run_id = run_response.json()["id"]
+
+    body = await _poll_until(client, run_id, {"failed"})
+    assert body["status"] == "failed"
+    assert len(body["checkpoints"]) >= 1
+
+    retry = await client.post(f"/v1/runs/{run_id}/retry")
+    assert retry.status_code == 202, retry.text
+    assert retry.json()["status"] == "pending"
+
+    body = await _poll_until(client, run_id, {"succeeded", "failed"})
+    assert body["status"] == "succeeded", body
+    assert body["output"] == {"reply": "echo: retry-me"}
+
+
+@pytest.mark.asyncio
+async def test_resume_waiting_human(client):
+    create = await client.post(
+        "/v1/agents",
+        json={
+            "name": "resume-bot",
+            "adapter": "echo",
+            "config": {"delay": 0, "pause_before_reply": True},
+        },
+    )
+    agent_id = create.json()["id"]
+
+    run_response = await client.post(
+        "/v1/runs",
+        json={"agent_id": agent_id, "input": {"prompt": "hold"}},
+    )
+    run_id = run_response.json()["id"]
+
+    body = await _poll_until(client, run_id, {"waiting_human"})
+    assert body["status"] == "waiting_human"
+
+    resume = await client.post(
+        f"/v1/runs/{run_id}/resume",
+        json={"input": {"approval": "ok"}},
+    )
+    assert resume.status_code == 202, resume.text
+
+    body = await _poll_until(client, run_id, {"succeeded", "failed"})
+    assert body["status"] == "succeeded", body
+    assert "ok" in body["output"]["reply"]
+
+
+@pytest.mark.asyncio
+async def test_retry_conflict_when_not_failed(client):
+    create = await client.post(
+        "/v1/agents",
+        json={"name": "ok-bot", "adapter": "echo", "config": {"delay": 0}},
+    )
+    agent_id = create.json()["id"]
+    run_response = await client.post(
+        "/v1/runs",
+        json={"agent_id": agent_id, "input": {"prompt": "x"}},
+    )
+    run_id = run_response.json()["id"]
+    await _poll_until(client, run_id, {"succeeded"})
+
+    retry = await client.post(f"/v1/runs/{run_id}/retry")
+    assert retry.status_code == 409

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -92,6 +92,40 @@ Response: a `Run` populated with `steps`, `messages`, and `checkpoints`.
 Signals the worker to cancel the run. Idempotent; returns 204 whether or not
 the run is already in a terminal state. Returns 404 if the run does not exist.
 
+### `POST /v1/runs/{id}/retry` → 202
+
+Re-queues a **failed** run for another worker attempt. The latest checkpoint is
+used when present; pass an explicit index to resume from an older snapshot.
+
+Request (optional body):
+
+```json
+{
+  "checkpoint_index": 0
+}
+```
+
+Response: a full `Run` record with status `pending` (worker will transition to
+`running`). Returns **404** if the run does not exist, **409** if status is not
+`failed` or the checkpoint index is missing.
+
+### `POST /v1/runs/{id}/resume` → 202
+
+Continues a run in **`waiting_human`** after human approval. The optional body
+is merged into the run's persisted `input` and forwarded to the adapter via
+resume metadata.
+
+Request (optional body):
+
+```json
+{
+  "input": { "approval": "approved" }
+}
+```
+
+Response: a full `Run` record with status `pending`. Returns **404** if missing,
+**409** if status is not `waiting_human`.
+
 ### `GET /v1/events/{run_id}` → 200 `text/event-stream`
 
 Server-Sent Events stream of `RunEvent` records. Stays open until the run
@@ -114,6 +148,7 @@ payload below as `data`:
 The supported `type` values are:
 
 `run.created`, `run.started`, `run.completed`, `run.failed`, `run.cancelled`,
+`run.waiting_human`,
 `step.started`, `step.updated`, `step.completed`, `step.failed`, `token.delta`,
 `message.created`, `tool_call.started`, `tool_call.completed`,
 `checkpoint.created`, `log`.

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -22,6 +22,16 @@ export const api = {
   getRun: (id: string) => request<Run>(`/v1/runs/${id}`),
   cancelRun: (id: string) =>
     request<void>(`/v1/runs/${id}/cancel`, { method: "POST" }),
+  retryRun: (id: string, body?: { checkpoint_index?: number }) =>
+    request<Run>(`/v1/runs/${id}/retry`, {
+      method: "POST",
+      body: JSON.stringify(body ?? {}),
+    }),
+  resumeRun: (id: string, body?: { input?: Record<string, unknown> }) =>
+    request<Run>(`/v1/runs/${id}/resume`, {
+      method: "POST",
+      body: JSON.stringify(body ?? {}),
+    }),
   createRun: (body: { agent_id: string; input: Record<string, unknown> }) =>
     request<Run>("/v1/runs", { method: "POST", body: JSON.stringify(body) }),
   listAgents: () => request<Agent[]>("/v1/agents"),

--- a/new feat
+++ b/new feat
@@ -1,0 +1,7 @@
+feat: add retry and resume functionality for runs
+    
+    - Implemented endpoints to retry failed runs and resume runs waiting for human approval.
+    - Introduced RunRetry and RunResume schemas to handle request payloads.
+    - Enhanced RunService to manage run states and checkpoint handling during retries and resumes.
+    - Updated EchoAdapter and LangGraphAdapter to support retryand resume logic.
+    - Added tests to validate the new functionality and ensure proper handling of run states.


### PR DESCRIPTION
 add retry and resume functionality for runs
    
    - Implemented endpoints to retry failed runs and resume runs waiting for human approval.
    - Introduced RunRetry and RunResume schemas to handle request payloads.
    - Enhanced RunService to manage run states and checkpoint handling during retries and resumes.
    - Updated EchoAdapter and LangGraphAdapter to support retryand resume logic.
    - Added tests to validate the new functionality and ensure proper handling of run states.