### PR TITLE
feat: add cost estimation and usage tracking for runs

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/dto/RunResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunResponse.java
@@ -20,10 +20,13 @@ public class RunResponse {
     private List<StepResponse> steps;
     private List<MessageResponse> messages;
     private List<CheckpointResponse> checkpoints;
+    private RunUsage usage = RunUsage.empty();
 
     /** Run header only; nested collections are empty (used by {@code GET /v1/runs}). */
     public static RunResponse fromEntity(RunEntity entity) {
-        return fromEntity(entity, List.of(), List.of(), List.of());
+        RunUsage stored = RunUsage.fromMetadata(entity.getMetadata());
+        RunUsage usage = stored != null ? stored : RunUsage.empty();
+        return fromEntity(entity, List.of(), List.of(), List.of(), usage);
     }
 
     public static RunResponse fromEntity(
@@ -31,6 +34,21 @@ public class RunResponse {
             List<StepResponse> steps,
             List<MessageResponse> messages,
             List<CheckpointResponse> checkpoints) {
+        RunUsage usage = steps.isEmpty()
+                ? RunUsage.fromMetadata(entity.getMetadata())
+                : RunUsage.fromSteps(steps);
+        if (usage == null) {
+            usage = RunUsage.empty();
+        }
+        return fromEntity(entity, steps, messages, checkpoints, usage);
+    }
+
+    public static RunResponse fromEntity(
+            RunEntity entity,
+            List<StepResponse> steps,
+            List<MessageResponse> messages,
+            List<CheckpointResponse> checkpoints,
+            RunUsage usage) {
         RunResponse dto = new RunResponse();
         dto.id = entity.getId();
         dto.agentId = entity.getAgentId();
@@ -44,6 +62,7 @@ public class RunResponse {
         dto.steps = steps;
         dto.messages = messages;
         dto.checkpoints = checkpoints;
+        dto.usage = usage;
         return dto;
     }
 
@@ -93,5 +112,9 @@ public class RunResponse {
 
     public List<CheckpointResponse> getCheckpoints() {
         return checkpoints;
+    }
+
+    public RunUsage getUsage() {
+        return usage;
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/dto/RunUsage.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunUsage.java
@@ -1,0 +1,90 @@
+package io.agentflow.api.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public class RunUsage {
+
+    private int tokensIn;
+    private int tokensOut;
+    private double costUsd;
+    private Integer latencyMs;
+
+    public static RunUsage empty() {
+        return new RunUsage();
+    }
+
+    public static RunUsage fromSteps(List<StepResponse> steps) {
+        RunUsage usage = new RunUsage();
+        if (steps == null || steps.isEmpty()) {
+            return usage;
+        }
+        int latencySum = 0;
+        boolean hasLatency = false;
+        for (StepResponse step : steps) {
+            if (step.getTokensIn() != null) {
+                usage.tokensIn += step.getTokensIn();
+            }
+            if (step.getTokensOut() != null) {
+                usage.tokensOut += step.getTokensOut();
+            }
+            if (step.getCostUsd() != null) {
+                usage.costUsd += step.getCostUsd();
+            }
+            if (step.getLatencyMs() != null) {
+                latencySum += step.getLatencyMs();
+                hasLatency = true;
+            }
+        }
+        usage.costUsd = Math.round(usage.costUsd * 1_000_000.0) / 1_000_000.0;
+        if (hasLatency) {
+            usage.latencyMs = latencySum;
+        }
+        return usage;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static RunUsage fromMetadata(Map<String, Object> metadata) {
+        if (metadata == null) {
+            return null;
+        }
+        Object raw = metadata.get("usage");
+        if (!(raw instanceof Map<?, ?> map)) {
+            return null;
+        }
+        RunUsage usage = new RunUsage();
+        Object tin = map.get("tokens_in");
+        if (tin instanceof Number n) {
+            usage.tokensIn = n.intValue();
+        }
+        Object tout = map.get("tokens_out");
+        if (tout instanceof Number n) {
+            usage.tokensOut = n.intValue();
+        }
+        Object cost = map.get("cost_usd");
+        if (cost instanceof Number n) {
+            usage.costUsd = n.doubleValue();
+        }
+        Object latency = map.get("latency_ms");
+        if (latency instanceof Number n) {
+            usage.latencyMs = n.intValue();
+        }
+        return usage;
+    }
+
+    public int getTokensIn() {
+        return tokensIn;
+    }
+
+    public int getTokensOut() {
+        return tokensOut;
+    }
+
+    public double getCostUsd() {
+        return costUsd;
+    }
+
+    public Integer getLatencyMs() {
+        return latencyMs;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/StepResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/StepResponse.java
@@ -18,6 +18,7 @@ public class StepResponse {
     private Integer latencyMs;
     private Integer tokensIn;
     private Integer tokensOut;
+    private Double costUsd;
     private List<ToolCallResponse> toolCalls;
     private Instant createdAt;
     private Instant updatedAt;
@@ -34,6 +35,7 @@ public class StepResponse {
         dto.latencyMs = entity.getLatencyMs();
         dto.tokensIn = entity.getTokensIn();
         dto.tokensOut = entity.getTokensOut();
+        dto.costUsd = entity.getCostUsd();
         dto.toolCalls = toolCalls;
         dto.createdAt = entity.getCreatedAt();
         dto.updatedAt = entity.getUpdatedAt();
@@ -78,6 +80,10 @@ public class StepResponse {
 
     public Integer getTokensOut() {
         return tokensOut;
+    }
+
+    public Double getCostUsd() {
+        return costUsd;
     }
 
     public List<ToolCallResponse> getToolCalls() {

--- a/backend-java/src/main/java/io/agentflow/api/entity/StepEntity.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/StepEntity.java
@@ -55,6 +55,9 @@ public class StepEntity {
     @Column(name = "tokens_out")
     private Integer tokensOut;
 
+    @Column(name = "cost_usd")
+    private Double costUsd;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
@@ -160,6 +163,14 @@ public class StepEntity {
 
     public void setTokensOut(Integer tokensOut) {
         this.tokensOut = tokensOut;
+    }
+
+    public Double getCostUsd() {
+        return costUsd;
+    }
+
+    public void setCostUsd(Double costUsd) {
+        this.costUsd = costUsd;
     }
 
     public Instant getCreatedAt() {

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -68,6 +68,7 @@ def upgrade() -> None:
         sa.Column("latency_ms", sa.Integer, nullable=True),
         sa.Column("tokens_in", sa.Integer, nullable=True),
         sa.Column("tokens_out", sa.Integer, nullable=True),
+        sa.Column("cost_usd", sa.Float, nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
     )

--- a/backend/alembic/versions/0002_step_cost_usd.py
+++ b/backend/alembic/versions/0002_step_cost_usd.py
@@ -1,0 +1,17 @@
+"""Add per-step cost_usd for token/cost accounting."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_step_cost_usd"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("steps", sa.Column("cost_usd", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("steps", "cost_usd")

--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -65,15 +65,18 @@ class AdapterContext:
         index: int,
         tokens_in: int | None = None,
         tokens_out: int | None = None,
+        cost_usd: float | None = None,
         latency_ms: int | None = None,
         **data: Any,
     ) -> None:
-        """Flush deferred step metrics (tokens, latency) without completing the step."""
+        """Flush deferred step metrics (tokens, cost, latency) without completing the step."""
         payload: dict[str, Any] = {"index": index, **data}
         if tokens_in is not None:
             payload["tokens_in"] = tokens_in
         if tokens_out is not None:
             payload["tokens_out"] = tokens_out
+        if cost_usd is not None:
+            payload["cost_usd"] = cost_usd
         if latency_ms is not None:
             payload["latency_ms"] = latency_ms
         await self.emit("step.updated", payload)

--- a/backend/app/adapters/echo_adapter.py
+++ b/backend/app/adapters/echo_adapter.py
@@ -18,6 +18,8 @@ from typing import Any
 
 from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
 from app.models.run import RunStatus
+from app.runtime.pricing import estimate_cost_usd
+from app.runtime.tokens import estimate_tokens
 _STEPS = ("plan", "tool", "reply")
 
 
@@ -103,10 +105,25 @@ class EchoAdapter(OrchestratorAdapter):
                 reply = f"{reply} ({approval})"
 
         idx = _step_index(ctx, 2, start)
+        model = str(ctx.agent_config.get("model", "echo"))
+        tokens_in = estimate_tokens(str(prompt))
+        tokens_out = estimate_tokens(reply)
+        cost_usd = estimate_cost_usd(model, tokens_in, tokens_out)
         await ctx.emit_step_started(index=idx, node="reply")
         await ctx.emit_message(role="assistant", content=reply)
+        await ctx.emit_step_updated(
+            index=idx,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
+        )
         await ctx.emit_step_completed(
-            index=idx, node="reply", output={"reply": reply}
+            index=idx,
+            node="reply",
+            output={"reply": reply},
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
         )
 
         return AdapterResult(status=RunStatus.SUCCEEDED, output={"reply": reply})

--- a/backend/app/adapters/langgraph_adapter.py
+++ b/backend/app/adapters/langgraph_adapter.py
@@ -47,6 +47,8 @@ from app.adapters.tool_registry import ToolDefinition, resolve_tools, tool_schem
 from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.models.run import RunStatus
+from app.runtime.pricing import estimate_cost_usd
+from app.runtime.tokens import estimate_tokens
 
 logger = get_logger("adapter.langgraph")
 
@@ -321,10 +323,13 @@ class LangGraphAdapter(OrchestratorAdapter):
             )
             latency_ms = int((time.monotonic() - started) * 1000)
 
+            cost_usd = estimate_cost_usd(model, tokens_in, tokens_out)
+
             await ctx.emit_step_updated(
                 index=step_idx,
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
+                cost_usd=cost_usd,
                 latency_ms=latency_ms,
             )
             await ctx.emit_message(role="assistant", content=reply)
@@ -334,6 +339,7 @@ class LangGraphAdapter(OrchestratorAdapter):
                 output={"reply": reply},
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
+                cost_usd=cost_usd,
                 latency_ms=latency_ms,
             )
             messages = list(state.get("messages") or [])
@@ -414,8 +420,8 @@ class LangGraphAdapter(OrchestratorAdapter):
             else:
                 reply = message.get("content") or ""
             usage = data.get("usage") or {}
-            tokens_in = int(usage.get("prompt_tokens") or _estimate_tokens(system_prompt + user_input))
-            tokens_out = int(usage.get("completion_tokens") or _estimate_tokens(reply))
+            tokens_in = int(usage.get("prompt_tokens") or estimate_tokens(system_prompt + user_input))
+            tokens_out = int(usage.get("completion_tokens") or estimate_tokens(reply))
             return reply, tokens_in, tokens_out
 
     async def _invoke_mock(
@@ -433,8 +439,8 @@ class LangGraphAdapter(OrchestratorAdapter):
         if tool_keys:
             suffix = f" [tools={','.join(tool_keys)}]"
         reply = f"[mock:{model}]{suffix} {user_input}"
-        tokens_in = _estimate_tokens(system_prompt + user_input)
-        tokens_out = _estimate_tokens(reply)
+        tokens_in = estimate_tokens(system_prompt + user_input)
+        tokens_out = estimate_tokens(reply)
         if stream_tokens:
             for chunk in _chunk_text(reply):
                 await ctx.emit_token_delta(step_index=step_index, delta=chunk)
@@ -493,19 +499,12 @@ class LangGraphAdapter(OrchestratorAdapter):
 
         reply = "".join(parts)
         if not tokens_in:
-            tokens_in = _estimate_tokens(
+            tokens_in = estimate_tokens(
                 str(payload.get("messages", ""))
             )
         if not tokens_out:
-            tokens_out = _estimate_tokens(reply)
+            tokens_out = estimate_tokens(reply)
         return reply, tokens_in, tokens_out
-
-
-def _estimate_tokens(text: str) -> int:
-    """Rough token estimate when the provider omits usage (≈4 chars/token)."""
-    if not text:
-        return 0
-    return max(1, len(text) // 4)
 
 
 def _initial_graph_state(ctx: AdapterContext) -> dict[str, Any]:

--- a/backend/app/api/v1/runs.py
+++ b/backend/app/api/v1/runs.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.events import EventBus, get_event_bus
-from app.schemas.run import RunCreate, RunRead, RunResume, RunRetry
+from app.schemas.run import RunCreate, RunRead, RunResume, RunRetry, run_read_from_orm
 from app.services.run_service import (
     AgentNotFound,
     RunConflict,
@@ -32,7 +32,7 @@ async def create_run(
 
     await service.start_run(run.id)
     run = await service.get_run(run.id, with_relations=True)
-    return RunRead.model_validate(run)
+    return run_read_from_orm(run)
 
 
 @router.get("", response_model=list[RunRead])
@@ -40,7 +40,7 @@ async def list_runs(
     limit: int = 50, service: RunService = Depends(get_run_service)
 ) -> list[RunRead]:
     runs = await service.list_runs(limit=limit)
-    return [RunRead.model_validate(run) for run in runs]
+    return [run_read_from_orm(run) for run in runs]
 
 
 @router.get("/{run_id}", response_model=RunRead)
@@ -51,7 +51,7 @@ async def get_run(
         run = await service.get_run(run_id, with_relations=True)
     except RunNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
-    return RunRead.model_validate(run)
+    return run_read_from_orm(run)
 
 
 @router.post("/{run_id}/cancel", status_code=status.HTTP_204_NO_CONTENT)
@@ -76,7 +76,7 @@ async def retry_run(
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
     except RunConflict as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return RunRead.model_validate(run)
+    return run_read_from_orm(run)
 
 
 @router.post("/{run_id}/resume", response_model=RunRead, status_code=status.HTTP_202_ACCEPTED)
@@ -91,4 +91,4 @@ async def resume_run(
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
     except RunConflict as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return RunRead.model_validate(run)
+    return run_read_from_orm(run)

--- a/backend/app/models/run.py
+++ b/backend/app/models/run.py
@@ -97,6 +97,7 @@ class Step(Base):
     latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     tokens_in: Mapped[int | None] = mapped_column(Integer, nullable=True)
     tokens_out: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_usd: Mapped[float | None] = mapped_column(nullable=True)
 
     run: Mapped[Run] = relationship(back_populates="steps")
     tool_calls: Mapped[list[ToolCall]] = relationship(

--- a/backend/app/runtime/pricing.py
+++ b/backend/app/runtime/pricing.py
@@ -1,0 +1,34 @@
+"""Model pricing for cost estimation (USD per 1M tokens)."""
+
+from __future__ import annotations
+
+# OpenAI list prices (2026-05); unknown models fall back to gpt-4o-mini.
+_MODEL_PRICING_PER_1M: dict[str, dict[str, float]] = {
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4.1-mini": {"input": 0.40, "output": 1.60},
+    "gpt-4.1": {"input": 2.00, "output": 8.00},
+    "echo": {"input": 0.0, "output": 0.0},
+}
+
+
+def _normalize_model(model: str) -> str:
+    name = (model or "").strip().lower()
+    if "/" in name:
+        name = name.split("/", 1)[1]
+    return name
+
+
+def estimate_cost_usd(model: str, tokens_in: int, tokens_out: int) -> float:
+    """Estimate step/run cost from token counts and a model id."""
+    key = _normalize_model(model)
+    rates = _MODEL_PRICING_PER_1M.get(key)
+    if rates is None:
+        for candidate, table in _MODEL_PRICING_PER_1M.items():
+            if key.startswith(candidate):
+                rates = table
+                break
+    if rates is None:
+        rates = _MODEL_PRICING_PER_1M["gpt-4o-mini"]
+    cost = (tokens_in * rates["input"] + tokens_out * rates["output"]) / 1_000_000
+    return round(cost, 6)

--- a/backend/app/runtime/tokens.py
+++ b/backend/app/runtime/tokens.py
@@ -1,0 +1,8 @@
+"""Token estimation helpers shared by adapters."""
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate when the provider omits usage (≈4 chars/token)."""
+    if not text:
+        return 0
+    return max(1, len(text) // 4)

--- a/backend/app/runtime/usage.py
+++ b/backend/app/runtime/usage.py
@@ -1,0 +1,71 @@
+"""Run-level token and cost aggregation."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from pydantic import BaseModel, Field
+
+
+class RunUsage(BaseModel):
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
+    latency_ms: int | None = None
+
+
+def _step_tokens_in(step: Any) -> int:
+    value = getattr(step, "tokens_in", None)
+    return int(value) if value is not None else 0
+
+
+def _step_tokens_out(step: Any) -> int:
+    value = getattr(step, "tokens_out", None)
+    return int(value) if value is not None else 0
+
+
+def _step_cost_usd(step: Any) -> float:
+    value = getattr(step, "cost_usd", None)
+    return float(value) if value is not None else 0.0
+
+
+def _step_latency_ms(step: Any) -> int | None:
+    value = getattr(step, "latency_ms", None)
+    return int(value) if value is not None else None
+
+
+def aggregate_run_usage(steps: Iterable[Any]) -> RunUsage:
+    """Sum metrics across all steps for a run."""
+    tokens_in = 0
+    tokens_out = 0
+    cost_usd = 0.0
+    latency_sum = 0
+    has_latency = False
+
+    for step in steps:
+        tokens_in += _step_tokens_in(step)
+        tokens_out += _step_tokens_out(step)
+        cost_usd += _step_cost_usd(step)
+        latency = _step_latency_ms(step)
+        if latency is not None:
+            latency_sum += latency
+            has_latency = True
+
+    return RunUsage(
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        cost_usd=round(cost_usd, 6),
+        latency_ms=latency_sum if has_latency else None,
+    )
+
+
+def usage_from_metadata(metadata: dict[str, Any] | None) -> RunUsage | None:
+    if not metadata:
+        return None
+    raw = metadata.get("usage")
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return RunUsage.model_validate(raw)
+    except Exception:
+        return None

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -5,6 +5,7 @@ from app.schemas.run import (
     RunCreate,
     RunEvent,
     RunRead,
+    run_read_from_orm,
     StepRead,
     ToolCallRead,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "RunCreate",
     "RunEvent",
     "RunRead",
+    "run_read_from_orm",
     "StepRead",
     "ToolCallRead",
 ]

--- a/backend/app/schemas/run.py
+++ b/backend/app/schemas/run.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from app.models.run import RunStatus
+from app.models.run import Run, RunStatus
+from app.runtime.usage import RunUsage, aggregate_run_usage, usage_from_metadata
 
 
 class RunCreate(BaseModel):
@@ -67,6 +68,7 @@ class StepRead(BaseModel):
     latency_ms: int | None
     tokens_in: int | None
     tokens_out: int | None
+    cost_usd: float | None = None
     tool_calls: list[ToolCallRead] = []
     created_at: datetime
     updated_at: datetime
@@ -96,6 +98,24 @@ class RunRead(BaseModel):
     steps: list[StepRead] = []
     messages: list[MessageRead] = []
     checkpoints: list[CheckpointRead] = []
+    usage: RunUsage = Field(default_factory=RunUsage)
+
+    @model_validator(mode="after")
+    def fill_usage(self) -> "RunRead":
+        if self.steps:
+            return self.model_copy(update={"usage": aggregate_run_usage(self.steps)})
+        return self
+
+
+def run_read_from_orm(run: Run) -> RunRead:
+    """Build API run DTO with usage from steps or persisted metadata."""
+    dto = RunRead.model_validate(run)
+    if dto.steps:
+        return dto
+    stored = usage_from_metadata(run.metadata_)
+    if stored is not None:
+        return dto.model_copy(update={"usage": stored})
+    return dto
 
 
 EventType = Literal[

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -30,6 +30,7 @@ from app.models import (
     Step,
     ToolCall,
 )
+from app.runtime.usage import aggregate_run_usage
 from app.schemas.run import EventType, RunCreate, RunEvent, RunResume, RunRetry
 from app.runtime.resume_context import (
     RunResumeContext,
@@ -283,16 +284,26 @@ class RunService:
         output: dict[str, Any] | None = None,
         error: str | None = None,
     ) -> None:
-        run = await self._get_run(run_id)
+        run = await self._get_run(run_id, with_relations=True)
         run.status = status
         if output is not None:
             run.output = output
         if error is not None:
             run.error = error
+        usage = aggregate_run_usage(run.steps)
+        if usage.tokens_in or usage.tokens_out or usage.cost_usd:
+            meta = dict(run.metadata_ or {})
+            meta["usage"] = usage.model_dump()
+            run.metadata_ = meta
         await self.session.commit()
 
+        usage_payload = usage.model_dump()
         if status == RunStatus.SUCCEEDED:
-            await self._broadcast("run.completed", run_id, {"output": output})
+            await self._broadcast(
+                "run.completed",
+                run_id,
+                {"output": output, "usage": usage_payload},
+            )
         elif status == RunStatus.FAILED:
             await self._broadcast("run.failed", run_id, {"error": error})
         elif status == RunStatus.CANCELLED:
@@ -338,6 +349,8 @@ class RunService:
                     step.tokens_in = data["tokens_in"]
                 if "tokens_out" in data:
                     step.tokens_out = data["tokens_out"]
+                if "cost_usd" in data:
+                    step.cost_usd = data["cost_usd"]
                 await self.session.commit()
         elif event_type == "step.completed":
             step = await self._find_step(run_id, data["index"])
@@ -350,6 +363,8 @@ class RunService:
                     step.tokens_in = data["tokens_in"]
                 if "tokens_out" in data:
                     step.tokens_out = data["tokens_out"]
+                if "cost_usd" in data:
+                    step.cost_usd = data["cost_usd"]
                 await self.session.commit()
         elif event_type == "token.delta":
             # SSE-only: avoid per-chunk DB commits during streaming.

--- a/backend/tests/test_langgraph_adapter.py
+++ b/backend/tests/test_langgraph_adapter.py
@@ -149,6 +149,7 @@ async def test_langgraph_streams_token_deltas_and_defers_step_tokens():
     assert len(updated) == 1
     assert updated[0]["tokens_in"] > 0
     assert updated[0]["tokens_out"] > 0
+    assert updated[0]["cost_usd"] >= 0
     assert updated[0]["latency_ms"] >= 0
 
     completed = [

--- a/backend/tests/test_runs.py
+++ b/backend/tests/test_runs.py
@@ -33,6 +33,11 @@ async def test_echo_run_end_to_end(client):
     assert len(body["steps"]) == 3
     assert {step["node"] for step in body["steps"]} == {"plan", "tool", "reply"}
     assert any(msg["role"] == "assistant" for msg in body["messages"])
+    assert body["usage"]["tokens_in"] > 0
+    assert body["usage"]["tokens_out"] > 0
+    reply_step = next(s for s in body["steps"] if s["node"] == "reply")
+    assert reply_step["tokens_in"] is not None
+    assert reply_step["cost_usd"] is not None
 
 
 async def _poll_until(client, run_id: str, statuses: set[str], *, attempts: int = 80):

--- a/backend/tests/test_usage.py
+++ b/backend/tests/test_usage.py
@@ -1,0 +1,29 @@
+from app.runtime.pricing import estimate_cost_usd
+from app.runtime.usage import RunUsage, aggregate_run_usage
+
+
+def test_estimate_cost_usd_known_model():
+    cost = estimate_cost_usd("openai/gpt-4o-mini", 1000, 500)
+    assert cost == round((1000 * 0.15 + 500 * 0.60) / 1_000_000, 6)
+
+
+def test_aggregate_run_usage_sums_steps():
+    class Step:
+        def __init__(self, **kwargs):
+            self.tokens_in = kwargs.get("tokens_in")
+            self.tokens_out = kwargs.get("tokens_out")
+            self.cost_usd = kwargs.get("cost_usd")
+            self.latency_ms = kwargs.get("latency_ms")
+
+    usage = aggregate_run_usage(
+        [
+            Step(tokens_in=10, tokens_out=20, cost_usd=0.001, latency_ms=100),
+            Step(tokens_in=5, tokens_out=15, cost_usd=0.002, latency_ms=50),
+        ]
+    )
+    assert usage == RunUsage(
+        tokens_in=15,
+        tokens_out=35,
+        cost_usd=0.003,
+        latency_ms=150,
+    )

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -163,7 +163,7 @@ The supported `type` values are:
 before `step.completed`:
 
 ```json
-{ "index": 0, "tokens_in": 42, "tokens_out": 128, "latency_ms": 1200 }
+{ "index": 0, "tokens_in": 42, "tokens_out": 128, "cost_usd": 0.00012, "latency_ms": 1200 }
 ```
 
 ## Schemas
@@ -198,6 +198,22 @@ before `step.completed`:
   steps: Step[];
   messages: Message[];
   checkpoints: Checkpoint[];
+  usage: RunUsage;
+}
+```
+
+### `RunUsage`
+
+Aggregated token and cost metrics for a run. Computed from `steps` when
+present; otherwise read from `metadata.usage` (written when the run reaches a
+terminal state).
+
+```ts
+{
+  tokens_in: number;
+  tokens_out: number;
+  cost_usd: number;
+  latency_ms: number | null;
 }
 ```
 
@@ -215,6 +231,7 @@ before `step.completed`:
   latency_ms: number | null;
   tokens_in: number | null;
   tokens_out: number | null;
+  cost_usd: number | null;
   tool_calls: ToolCall[];
   created_at: string;
   updated_at: string;

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -43,6 +43,7 @@ erDiagram
         int latency_ms
         int tokens_in
         int tokens_out
+        float cost_usd
     }
     Message {
         string id PK

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -43,7 +43,7 @@
 **目标：** 在控制台内完成调试、重试与成本核算。
 
 - [ ] Step 时间线组件（节点延迟与状态）
-- [ ] Adapter 写入 token/成本；Run 级汇总
+- [x] Adapter 写入 token/成本；Run 级汇总
 - [ ] `POST /v1/runs/{id}/retry` 与 `POST /v1/runs/{id}/resume`
 - [ ] SSE 事件重放（`Last-Event-ID`）
 - [x] OpenTelemetry 全链路 trace（API → worker → adapter，RED 指标 + trace 传播）

--- a/frontend/app/runs/[id]/page.tsx
+++ b/frontend/app/runs/[id]/page.tsx
@@ -119,7 +119,7 @@ export default function RunDetailPage({ params }: PageProps) {
                     {s.tokens_in ?? 0}→{s.tokens_out ?? 0} tok
                   </span>
                 )}
-                {s.cost_usd != null && s.cost_usd > 0 && (
+                {s.cost_usd != null && (
                   <span className="text-xs text-accent font-mono">
                     {formatCostUsd(s.cost_usd)}
                   </span>

--- a/frontend/app/runs/[id]/page.tsx
+++ b/frontend/app/runs/[id]/page.tsx
@@ -6,6 +6,8 @@ import { use } from "react";
 
 import { EventStream } from "@/components/EventStream";
 import { StatusBadge } from "@/components/StatusBadge";
+import { TokenCostSummary } from "@/components/TokenCostSummary";
+import { formatCostUsd } from "@/lib/usage";
 import { api } from "@/lib/api";
 
 interface PageProps {
@@ -77,6 +79,11 @@ export default function RunDetailPage({ params }: PageProps) {
         </div>
       ) : null}
 
+      <section className="rounded-lg border border-border bg-surface p-4 space-y-3">
+        <h2 className="font-medium">Token &amp; cost</h2>
+        <TokenCostSummary usage={r.usage} steps={r.steps} />
+      </section>
+
       <section className="grid gap-4 lg:grid-cols-2">
         <div className="rounded-lg border border-border bg-surface p-4 space-y-2">
           <h2 className="font-medium">Input</h2>
@@ -106,6 +113,16 @@ export default function RunDetailPage({ params }: PageProps) {
                 <StatusBadge status={s.status} />
                 {s.latency_ms != null && (
                   <span className="text-xs text-muted">{s.latency_ms}ms</span>
+                )}
+                {(s.tokens_in != null || s.tokens_out != null) && (
+                  <span className="text-xs text-muted font-mono">
+                    {s.tokens_in ?? 0}→{s.tokens_out ?? 0} tok
+                  </span>
+                )}
+                {s.cost_usd != null && s.cost_usd > 0 && (
+                  <span className="text-xs text-accent font-mono">
+                    {formatCostUsd(s.cost_usd)}
+                  </span>
                 )}
               </div>
               {s.tool_calls.length > 0 && (

--- a/frontend/app/runs/page.tsx
+++ b/frontend/app/runs/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 
 import { StatusBadge } from "@/components/StatusBadge";
 import { api } from "@/lib/api";
+import { formatCostUsd, hasUsageMetrics } from "@/lib/usage";
 
 export default function RunsPage() {
   const runs = useQuery({
@@ -31,6 +32,7 @@ export default function RunsPage() {
               <th className="px-4 py-2 font-medium">Run</th>
               <th className="px-4 py-2 font-medium">Adapter</th>
               <th className="px-4 py-2 font-medium">Status</th>
+              <th className="px-4 py-2 font-medium">Usage</th>
               <th className="px-4 py-2 font-medium">Created</th>
             </tr>
           </thead>
@@ -45,6 +47,18 @@ export default function RunsPage() {
                 <td className="px-4 py-2 font-mono text-xs">{r.adapter}</td>
                 <td className="px-4 py-2">
                   <StatusBadge status={r.status} />
+                </td>
+                <td className="px-4 py-2 text-xs font-mono text-muted">
+                  {hasUsageMetrics(r.usage) ? (
+                    <span>
+                      {r.usage.tokens_in + r.usage.tokens_out} tok ·{" "}
+                      <span className="text-accent">
+                        {formatCostUsd(r.usage.cost_usd)}
+                      </span>
+                    </span>
+                  ) : (
+                    "—"
+                  )}
                 </td>
                 <td className="px-4 py-2 text-xs text-muted">
                   {new Date(r.created_at).toLocaleString()}

--- a/frontend/components/TokenCostSummary.tsx
+++ b/frontend/components/TokenCostSummary.tsx
@@ -1,0 +1,100 @@
+import type { RunUsage, Step } from "@/lib/types";
+import {
+  formatCostUsd,
+  formatTokenCount,
+  hasUsageMetrics,
+  stepHasMetrics,
+} from "@/lib/usage";
+
+interface TokenCostSummaryProps {
+  usage: RunUsage;
+  steps?: Step[];
+  compact?: boolean;
+}
+
+export function TokenCostSummary({
+  usage,
+  steps = [],
+  compact = false,
+}: TokenCostSummaryProps) {
+  if (!hasUsageMetrics(usage)) {
+    return (
+      <p className="text-xs text-muted">
+        No token or cost data yet (LLM steps record usage when the adapter reports
+        it).
+      </p>
+    );
+  }
+
+  return (
+    <div className={compact ? "space-y-2" : "space-y-4"}>
+      <dl
+        className={
+          compact
+            ? "grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm"
+            : "grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm"
+        }
+      >
+        <div>
+          <dt className="text-xs text-muted uppercase tracking-wide">Tokens in</dt>
+          <dd className="font-mono tabular-nums">
+            {formatTokenCount(usage.tokens_in)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted uppercase tracking-wide">Tokens out</dt>
+          <dd className="font-mono tabular-nums">
+            {formatTokenCount(usage.tokens_out)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted uppercase tracking-wide">Est. cost</dt>
+          <dd className="font-mono tabular-nums text-accent">
+            {formatCostUsd(usage.cost_usd)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-muted uppercase tracking-wide">Latency</dt>
+          <dd className="font-mono tabular-nums">
+            {usage.latency_ms != null
+              ? `${formatTokenCount(usage.latency_ms)} ms`
+              : "—"}
+          </dd>
+        </div>
+      </dl>
+
+      {!compact && steps.some(stepHasMetrics) ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs border border-border rounded-lg overflow-hidden">
+            <thead className="text-left text-muted bg-bg">
+              <tr>
+                <th className="px-3 py-2 font-medium">Step</th>
+                <th className="px-3 py-2 font-medium">In</th>
+                <th className="px-3 py-2 font-medium">Out</th>
+                <th className="px-3 py-2 font-medium">Cost</th>
+                <th className="px-3 py-2 font-medium">Latency</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border font-mono tabular-nums">
+              {steps.filter(stepHasMetrics).map((s) => (
+                <tr key={s.id}>
+                  <td className="px-3 py-2">
+                    <span className="text-muted">#{s.index}</span> {s.node}
+                  </td>
+                  <td className="px-3 py-2">{s.tokens_in ?? "—"}</td>
+                  <td className="px-3 py-2">{s.tokens_out ?? "—"}</td>
+                  <td className="px-3 py-2 text-accent">
+                    {s.cost_usd != null ? formatCostUsd(s.cost_usd) : "—"}
+                  </td>
+                  <td className="px-3 py-2">
+                    {s.latency_ms != null ? `${s.latency_ms} ms` : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -26,9 +26,17 @@ export interface Step {
   latency_ms: number | null;
   tokens_in: number | null;
   tokens_out: number | null;
+  cost_usd: number | null;
   tool_calls: ToolCall[];
   created_at: string;
   updated_at: string;
+}
+
+export interface RunUsage {
+  tokens_in: number;
+  tokens_out: number;
+  cost_usd: number;
+  latency_ms: number | null;
 }
 
 export interface Message {
@@ -62,6 +70,7 @@ export interface Run {
   steps: Step[];
   messages: Message[];
   checkpoints: Checkpoint[];
+  usage: RunUsage;
 }
 
 export interface Agent {

--- a/frontend/lib/usage.ts
+++ b/frontend/lib/usage.ts
@@ -1,0 +1,23 @@
+import type { RunUsage, Step } from "./types";
+
+export function formatCostUsd(value: number): string {
+  if (value === 0) return "$0.00";
+  if (value < 0.01) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+export function formatTokenCount(value: number): string {
+  return value.toLocaleString();
+}
+
+export function hasUsageMetrics(usage: RunUsage): boolean {
+  return usage.tokens_in > 0 || usage.tokens_out > 0 || usage.cost_usd > 0;
+}
+
+export function stepHasMetrics(step: Step): boolean {
+  return (
+    (step.tokens_in ?? 0) > 0 ||
+    (step.tokens_out ?? 0) > 0 ||
+    (step.cost_usd ?? 0) > 0
+  );
+}


### PR DESCRIPTION
- Introduced cost_usd field in the steps table to track the cost associated with each step.
- Implemented cost estimation logic in pricing module based on token usage.
- Updated adapters to emit cost data during step updates.
- Enhanced Run and Step schemas to include usage metrics.
- Aggregated run usage metrics for better reporting and tracking.
- Updated API responses and frontend components to display usage and cost information.
- Added tests to validate cost estimation and usage aggregation functionality.