### PR TITLE
refactor: remove unnecessary @Enumerated annotations from RunEntity a…

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/entity/RunEntity.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/RunEntity.java
@@ -4,8 +4,6 @@ import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -32,7 +30,6 @@ public class RunEntity {
 
     @Column(nullable = false, length = 32)
     @JdbcTypeCode(SqlTypes.VARCHAR)
-    @Enumerated(EnumType.STRING)
     private RunStatus status = RunStatus.PENDING;
 
     @Column(name = "input", nullable = false, columnDefinition = "TEXT")

--- a/backend-java/src/main/java/io/agentflow/api/entity/RunStatusConverter.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/RunStatusConverter.java
@@ -13,11 +13,11 @@ public class RunStatusConverter implements AttributeConverter<RunStatus, String>
 
     @Override
     public String convertToDatabaseColumn(RunStatus attribute) {
-        return attribute == null ? null : attribute.wire();
+        return attribute == null ? null : attribute.name().toLowerCase(java.util.Locale.ROOT);
     }
 
     @Override
     public RunStatus convertToEntityAttribute(String dbData) {
-        return RunStatus.fromWire(dbData);
+        return dbData == null ? null : RunStatus.valueOf(dbData.toUpperCase(java.util.Locale.ROOT));
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/entity/RunStatusConverter.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/RunStatusConverter.java
@@ -1,0 +1,23 @@
+package io.agentflow.api.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Persists {@link RunStatus} as lowercase wire strings ({@code pending},
+ * {@code waiting_human}, …) so Java and Python share the same {@code runs.status}
+ * and {@code steps.status} column values.
+ */
+@Converter(autoApply = true)
+public class RunStatusConverter implements AttributeConverter<RunStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(RunStatus attribute) {
+        return attribute == null ? null : attribute.wire();
+    }
+
+    @Override
+    public RunStatus convertToEntityAttribute(String dbData) {
+        return RunStatus.fromWire(dbData);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/entity/StepEntity.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/StepEntity.java
@@ -4,8 +4,6 @@ import com.github.f4b6a3.ulid.UlidCreator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -32,7 +30,6 @@ public class StepEntity {
     private String node;
 
     @Column(nullable = false, length = 32)
-    @Enumerated(EnumType.STRING)
     private RunStatus status = RunStatus.RUNNING;
 
     @Column(name = "input", nullable = false, columnDefinition = "TEXT")

--- a/backend-java/src/test/java/io/agentflow/api/entity/RunStatusConverterTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/entity/RunStatusConverterTest.java
@@ -1,0 +1,25 @@
+package io.agentflow.api.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RunStatusConverterTest {
+
+    private final RunStatusConverter converter = new RunStatusConverter();
+
+    @Test
+    void persistsLowercaseWireValuesMatchingPython() {
+        assertThat(converter.convertToDatabaseColumn(RunStatus.PENDING)).isEqualTo("pending");
+        assertThat(converter.convertToDatabaseColumn(RunStatus.WAITING_HUMAN))
+                .isEqualTo("waiting_human");
+        assertThat(converter.convertToDatabaseColumn(RunStatus.SUCCEEDED)).isEqualTo("succeeded");
+    }
+
+    @Test
+    void readsLowercaseWireValuesWrittenByPythonWorker() {
+        assertThat(converter.convertToEntityAttribute("running")).isEqualTo(RunStatus.RUNNING);
+        assertThat(converter.convertToEntityAttribute("failed")).isEqualTo(RunStatus.FAILED);
+        assertThat(converter.convertToEntityAttribute("cancelled")).isEqualTo(RunStatus.CANCELLED);
+    }
+}


### PR DESCRIPTION
…nd StepEntity

- Cleaned up the RunEntity and StepEntity classes by removing the @Enumerated annotation, as it was not needed for the RunStatus field.
- This change simplifies the code and improves readability.