### PR TITLE
feat: enhance event streaming and publishing logic

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/controller/EventsController.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/EventsController.java
@@ -2,6 +2,7 @@ package io.agentflow.api.controller;
 
 import io.agentflow.api.service.EventStreamService;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,12 +22,17 @@ public class EventsController {
     }
 
     @GetMapping(value = "/{runId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(
+    public ResponseEntity<SseEmitter> stream(
             @PathVariable String runId,
             @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId,
             @RequestParam(value = "last_event_id", required = false) String lastEventIdParam) {
         String after =
                 lastEventId != null && !lastEventId.isBlank() ? lastEventId : lastEventIdParam;
-        return events.subscribe(runId, after);
+        SseEmitter emitter = events.subscribe(runId, after);
+        return ResponseEntity.ok()
+                .header("Cache-Control", "no-cache")
+                .header("Connection", "keep-alive")
+                .header("X-Accel-Buffering", "no")
+                .body(emitter);
     }
 }

--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from fastapi import APIRouter, Depends, Request
 from sse_starlette.sse import EventSourceResponse
 
+from app.core.config import get_settings
 from app.events import EventBus, get_event_bus
 from app.events.bus import _is_after
 from app.schemas.run import RunEvent
@@ -24,6 +25,12 @@ from app.schemas.run import RunEvent
 router = APIRouter(prefix="/events", tags=["events"])
 
 _TERMINAL_TYPES = {"run.completed", "run.failed", "run.cancelled"}
+
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
 
 
 def _resolve_last_event_id(request: Request) -> str | None:
@@ -36,12 +43,14 @@ def _resolve_last_event_id(request: Request) -> str | None:
     return None
 
 
-def _sse_frame(event_id: str, event: RunEvent) -> dict[str, str]:
-    return {
-        "id": event_id,
+def _sse_frame(event_id: str | None, event: RunEvent) -> dict[str, str]:
+    frame: dict[str, str] = {
         "event": event.type,
         "data": event.model_dump_json(),
     }
+    if event_id:
+        frame["id"] = event_id
+    return frame
 
 
 @router.get("/{run_id}")
@@ -51,6 +60,7 @@ async def stream_run_events(
     bus: EventBus = Depends(get_event_bus),
 ) -> EventSourceResponse:
     after_id = _resolve_last_event_id(request)
+    heartbeat = float(get_settings().event_sse_heartbeat_seconds)
 
     async def generator() -> AsyncIterator[dict[str, str]]:
         last_id = after_id
@@ -58,8 +68,9 @@ async def stream_run_events(
         async for event_id, event in bus.replay(run_id, after_id):
             if await request.is_disconnected():
                 return
-            yield _sse_frame(event_id, event)
-            last_id = event_id
+            yield _sse_frame(event_id or None, event)
+            if event_id:
+                last_id = event_id
             if event.type in _TERMINAL_TYPES:
                 return
 
@@ -67,8 +78,9 @@ async def stream_run_events(
             async for event_id, event in bus.replay(run_id, last_id):
                 if await request.is_disconnected():
                     return
-                yield _sse_frame(event_id, event)
-                last_id = event_id
+                yield _sse_frame(event_id or None, event)
+                if event_id:
+                    last_id = event_id
                 if event.type in _TERMINAL_TYPES:
                     return
 
@@ -77,7 +89,9 @@ async def stream_run_events(
                     break
 
                 try:
-                    event_id, event = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    event_id, event = await asyncio.wait_for(
+                        queue.get(), timeout=heartbeat
+                    )
                 except TimeoutError:
                     yield {"event": "ping", "data": "{}"}
                     continue
@@ -87,9 +101,13 @@ async def stream_run_events(
                 if event_id:
                     last_id = event_id
 
-                yield _sse_frame(event_id or "0", event)
+                yield _sse_frame(event_id or None, event)
 
                 if event.type in _TERMINAL_TYPES:
                     break
 
-    return EventSourceResponse(generator())
+    return EventSourceResponse(
+        generator(),
+        ping=int(heartbeat),
+        headers=_SSE_HEADERS,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -36,6 +36,12 @@ class Settings(BaseSettings):
         ge=100,
         description="Approximate max entries kept in each run's Redis event stream.",
     )
+    event_sse_heartbeat_seconds: int = Field(
+        default=15,
+        ge=1,
+        le=120,
+        description="SSE keepalive interval (comment + event: ping frames).",
+    )
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
 
     default_adapter: str = Field(

--- a/backend/app/events/bus.py
+++ b/backend/app/events/bus.py
@@ -38,7 +38,7 @@ def _is_after(entry_id: str, after_id: str | None) -> bool:
 
 
 class EventBus(Protocol):
-    async def publish(self, event: RunEvent) -> str: ...
+    async def publish(self, event: RunEvent, *, persist: bool = True) -> str: ...
 
     def replay(
         self, run_id: str, after_id: str | None = None
@@ -57,12 +57,16 @@ class InMemoryEventBus:
         self._seq: dict[str, int] = defaultdict(int)
         self._lock = asyncio.Lock()
 
-    async def publish(self, event: RunEvent) -> str:
+    async def publish(self, event: RunEvent, *, persist: bool = True) -> str:
         async with self._lock:
-            self._seq[event.run_id] += 1
-            event_id = str(self._seq[event.run_id])
-            record = (event_id, event)
-            self._log[event.run_id].append(record)
+            if persist:
+                self._seq[event.run_id] += 1
+                event_id = str(self._seq[event.run_id])
+                record = (event_id, event)
+                self._log[event.run_id].append(record)
+            else:
+                event_id = ""
+                record = (event_id, event)
             queues = list(self._subscribers.get(event.run_id, ()))
         for queue in queues:
             await queue.put(record)
@@ -110,14 +114,16 @@ class RedisEventBus:
     def _stream(self, run_id: str) -> str:
         return f"{self._channel_prefix}{run_id}{self._stream_suffix}"
 
-    async def publish(self, event: RunEvent) -> str:
-        stream = self._stream(event.run_id)
-        event_id = await self._redis.xadd(
-            stream,
-            {"payload": event.model_dump_json()},
-            maxlen=self._stream_max_len,
-            approximate=True,
-        )
+    async def publish(self, event: RunEvent, *, persist: bool = True) -> str:
+        event_id = ""
+        if persist:
+            stream = self._stream(event.run_id)
+            event_id = await self._redis.xadd(
+                stream,
+                {"payload": event.model_dump_json()},
+                maxlen=self._stream_max_len,
+                approximate=True,
+            )
         envelope = json.dumps({"id": event_id, "event": event.model_dump(mode="json")})
         await self._redis.publish(self._channel(event.run_id), envelope)
         return event_id

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -316,7 +316,12 @@ class RunService:
             )
 
     async def _broadcast(
-        self, event_type: EventType, run_id: str, data: dict[str, Any]
+        self,
+        event_type: EventType,
+        run_id: str,
+        data: dict[str, Any],
+        *,
+        persist: bool = True,
     ) -> None:
         event = RunEvent(
             type=event_type,
@@ -324,7 +329,7 @@ class RunService:
             at=datetime.now(UTC),
             data=data,
         )
-        await self.bus.publish(event)
+        await self.bus.publish(event, persist=persist)
 
     async def _handle_event(
         self, run_id: str, event_type: EventType, data: dict[str, Any]
@@ -367,8 +372,8 @@ class RunService:
                     step.cost_usd = data["cost_usd"]
                 await self.session.commit()
         elif event_type == "token.delta":
-            # SSE-only: avoid per-chunk DB commits during streaming.
-            await self._broadcast(event_type, run_id, data)
+            # SSE-only: live pub/sub without durable replay log or DB writes.
+            await self._broadcast(event_type, run_id, data, persist=False)
             return
         elif event_type == "step.failed":
             step = await self._find_step(run_id, data["index"])

--- a/backend/tests/test_event_replay.py
+++ b/backend/tests/test_event_replay.py
@@ -184,3 +184,44 @@ async def test_redis_event_bus_replay_with_fakeredis():
 
     full = [event.type async for _, event in bus.replay(run_id, None)]
     assert full == ["run.created", "run.started", "run.completed"]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_events_skip_replay_log():
+    bus = InMemoryEventBus()
+    run_id = "run-ephemeral"
+
+    id1 = await bus.publish(_event("run.created", run_id))
+    await bus.publish(_event("token.delta", run_id, step_index=0, delta="Hi"), persist=False)
+    id2 = await bus.publish(_event("run.completed", run_id, output={}))
+
+    replayed = [event.type async for _, event in bus.replay(run_id, None)]
+    assert replayed == ["run.created", "run.completed"]
+    assert id1 != id2
+
+
+@pytest.mark.asyncio
+async def test_redis_ephemeral_events_skip_stream():
+    redis = fakeredis.FakeRedis(decode_responses=True)
+    bus = RedisEventBus.__new__(RedisEventBus)
+    bus._redis = redis
+    bus._channel_prefix = "agentflow:run:"
+    bus._stream_suffix = ":log"
+    bus._stream_max_len = 1000
+
+    run_id = "run-redis-ephemeral"
+    id1 = await bus.publish(_event("run.created", run_id))
+    await bus.publish(
+        _event("token.delta", run_id, step_index=0, delta="x"),
+        persist=False,
+    )
+    id2 = await bus.publish(_event("run.completed", run_id, output={}))
+
+    stream = bus._stream(run_id)
+    entries = await redis.xrange(stream, min="-", max="+")
+    assert len(entries) == 2
+    assert entries[0][0] == id1
+    assert entries[1][0] == id2
+
+    replayed = [event.type async for _, event in bus.replay(run_id, None)]
+    assert replayed == ["run.created", "run.completed"]

--- a/frontend/lib/run-event-connection.ts
+++ b/frontend/lib/run-event-connection.ts
@@ -20,10 +20,14 @@ export interface RunEventConnectionHandlers {
   onEvent?: (event: RunEvent, clientSeq: number, eventId?: string) => void;
   onTerminal?: (event: RunEvent) => void;
   onStatusChange?: (status: RunEventConnectionStatus) => void;
+  /** Fires when a reconnect attempt succeeds (not the initial connect). */
+  onReconnected?: () => void;
 }
 
 const INITIAL_RECONNECT_MS = 1_000;
 const MAX_RECONNECT_MS = 30_000;
+const CONNECT_TIMEOUT_MS = 30_000;
+const WATCHDOG_INTERVAL_MS = 5_000;
 
 /** Mirrors backend `_is_after` — numeric IDs when possible, else lexicographic. */
 function isEventIdAfter(entryId: string, afterId: string): boolean {
@@ -55,10 +59,14 @@ export function createRunEventConnection(
   let cancelled = false;
   let source: EventSource | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let watchdogTimer: ReturnType<typeof setInterval> | null = null;
   let reconnectAttempt = 0;
   let terminal = false;
   let clientSeq = 0;
   let lastEventId: string | null = null;
+  let connectStartedAt = 0;
+  let lastActivityAt = 0;
+  let idleTimeoutMs = 45_000;
 
   const setStatus = (status: RunEventConnectionStatus) => {
     if (!cancelled) handlers.onStatusChange?.(status);
@@ -71,9 +79,21 @@ export function createRunEventConnection(
     }
   };
 
+  const stopWatchdog = () => {
+    if (watchdogTimer != null) {
+      clearInterval(watchdogTimer);
+      watchdogTimer = null;
+    }
+  };
+
+  const bumpActivity = () => {
+    lastActivityAt = Date.now();
+  };
+
   const closeSource = () => {
     if (!source) return;
     RUN_EVENT_TYPES.forEach((type) => source!.removeEventListener(type, onMessage));
+    source.removeEventListener("ping", onPing);
     source.onerror = null;
     source.close();
     source = null;
@@ -82,27 +102,64 @@ export function createRunEventConnection(
   const finishTerminal = (event: RunEvent) => {
     terminal = true;
     clearReconnectTimer();
+    stopWatchdog();
     closeSource();
     setStatus("closed");
     handlers.onTerminal?.(event);
   };
 
+  const startWatchdog = () => {
+    stopWatchdog();
+    watchdogTimer = setInterval(() => {
+      if (cancelled || terminal) return;
+
+      const now = Date.now();
+      const state = source?.readyState;
+
+      if (
+        state === EventSource.CONNECTING &&
+        connectStartedAt > 0 &&
+        now - connectStartedAt > CONNECT_TIMEOUT_MS
+      ) {
+        closeSource();
+        scheduleReconnect();
+        return;
+      }
+
+      if (state === EventSource.OPEN && now - lastActivityAt > idleTimeoutMs) {
+        closeSource();
+        scheduleReconnect();
+      }
+    }, WATCHDOG_INTERVAL_MS);
+  };
+
   const connect = () => {
     if (cancelled || terminal) return;
 
+    const isReconnect = reconnectAttempt > 0;
+
     clearReconnectTimer();
     closeSource();
-    setStatus(reconnectAttempt === 0 ? "connecting" : "reconnecting");
+    setStatus(isReconnect ? "reconnecting" : "connecting");
+
+    connectStartedAt = Date.now();
+    bumpActivity();
 
     const next = new EventSource(streamUrl(runId, lastEventId));
     source = next;
 
     next.addEventListener("open", () => {
       if (cancelled || terminal) return;
+      bumpActivity();
+      reconnectAttempt = 0;
       setStatus("connected");
+      if (isReconnect) {
+        handlers.onReconnected?.();
+      }
     });
 
     RUN_EVENT_TYPES.forEach((type) => next.addEventListener(type, onMessage));
+    next.addEventListener("ping", onPing);
 
     next.onerror = () => {
       if (cancelled || terminal) return;
@@ -148,8 +205,16 @@ export function createRunEventConnection(
     window.addEventListener("online", onOnline);
   }
 
+  const onPing = () => {
+    if (cancelled || terminal) return;
+    bumpActivity();
+    reconnectAttempt = 0;
+  };
+
   const onMessage = (event: MessageEvent) => {
     if (cancelled || terminal) return;
+
+    bumpActivity();
 
     const incomingId = event.lastEventId;
     if (incomingId) {
@@ -172,12 +237,15 @@ export function createRunEventConnection(
     }
   };
 
+  idleTimeoutMs = 45_000;
+  startWatchdog();
   connect();
 
   return {
     close: () => {
       cancelled = true;
       clearReconnectTimer();
+      stopWatchdog();
       closeSource();
       if (typeof document !== "undefined") {
         document.removeEventListener("visibilitychange", onVisibilityChange);

--- a/frontend/lib/useRunEventSource.ts
+++ b/frontend/lib/useRunEventSource.ts
@@ -18,6 +18,7 @@ interface UseRunEventSourceOptions {
   enabled?: boolean;
   onEvent?: (event: RunEvent) => void;
   onTerminal?: (event: RunEvent) => void;
+  onReconnected?: () => void;
 }
 
 export function useRunEventSource({
@@ -25,6 +26,7 @@ export function useRunEventSource({
   enabled = true,
   onEvent,
   onTerminal,
+  onReconnected,
 }: UseRunEventSourceOptions) {
   const [events, setEvents] = useState<StoredRunEvent[]>([]);
   const [status, setStatus] = useState<RunEventConnectionStatus>(
@@ -32,9 +34,11 @@ export function useRunEventSource({
   );
   const onEventRef = useRef(onEvent);
   const onTerminalRef = useRef(onTerminal);
+  const onReconnectedRef = useRef(onReconnected);
 
   onEventRef.current = onEvent;
   onTerminalRef.current = onTerminal;
+  onReconnectedRef.current = onReconnected;
 
   useEffect(() => {
     if (!enabled) {
@@ -54,6 +58,9 @@ export function useRunEventSource({
       onTerminal: (event) => {
         onTerminalRef.current?.(event);
       },
+      onReconnected: () => {
+        onReconnectedRef.current?.();
+      },
     });
 
     return () => connection.close();
@@ -66,18 +73,22 @@ interface UseMultiRunEventSourceOptions {
   runIds: string[];
   onEvent?: (event: RunEvent) => void;
   onTerminal?: (event: RunEvent) => void;
+  onReconnected?: (runId: string) => void;
 }
 
 export function useMultiRunEventSource({
   runIds,
   onEvent,
   onTerminal,
+  onReconnected,
 }: UseMultiRunEventSourceOptions) {
   const onEventRef = useRef(onEvent);
   const onTerminalRef = useRef(onTerminal);
+  const onReconnectedRef = useRef(onReconnected);
 
   onEventRef.current = onEvent;
   onTerminalRef.current = onTerminal;
+  onReconnectedRef.current = onReconnected;
 
   const runKey = runIds.slice().sort().join(",");
 
@@ -92,6 +103,9 @@ export function useMultiRunEventSource({
         },
         onTerminal: (event) => {
           onTerminalRef.current?.(event);
+        },
+        onReconnected: () => {
+          onReconnectedRef.current?.(runId);
         },
       }),
     );

--- a/frontend/lib/useRunLiveSync.ts
+++ b/frontend/lib/useRunLiveSync.ts
@@ -35,6 +35,9 @@ export function useRunsListLiveSync(liveRunIds: string[]) {
         reconcileRuns();
       }
     },
+    onReconnected: () => {
+      reconcileRuns();
+    },
     onTerminal: () => {
       reconcileRuns.cancel();
       queryClient.invalidateQueries({ queryKey: ["runs"] });
@@ -69,6 +72,9 @@ export function useRunWithLiveUpdates(runId: string) {
       if (shouldReconcileRun(event.type)) {
         reconcileRun();
       }
+    },
+    onReconnected: () => {
+      reconcileRun();
     },
     onTerminal: () => {
       reconcileRun.cancel();


### PR DESCRIPTION
- Introduced a heartbeat configuration for SSE connections to maintain active streams.
- Updated the event publishing mechanism to allow optional persistence of ephemeral events.
- Refactored the SSE frame generation to conditionally include event IDs.
- Improved event handling in the frontend to support reconnection logic and activity tracking.
- Added tests to ensure ephemeral events are correctly handled without persisting to the replay log.