### PR TITLE
feat: implement agent versioning and history management

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/controller/AgentsController.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/AgentsController.java
@@ -2,15 +2,20 @@ package io.agentflow.api.controller;
 
 import io.agentflow.api.dto.AgentCreateRequest;
 import io.agentflow.api.dto.AgentResponse;
+import io.agentflow.api.dto.AgentUpdateRequest;
+import io.agentflow.api.dto.AgentVersionDiffResponse;
+import io.agentflow.api.dto.AgentVersionResponse;
 import io.agentflow.api.service.AgentService;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,5 +43,35 @@ public class AgentsController {
     @GetMapping("/{id}")
     public AgentResponse get(@PathVariable String id) {
         return service.get(id);
+    }
+
+    @PatchMapping("/{id}")
+    public AgentResponse update(
+            @PathVariable String id, @RequestBody AgentUpdateRequest payload) {
+        return service.update(id, payload);
+    }
+
+    @GetMapping("/{id}/versions")
+    public List<AgentVersionResponse> listVersions(@PathVariable String id) {
+        return service.listVersions(id);
+    }
+
+    @GetMapping("/{id}/versions/diff")
+    public AgentVersionDiffResponse diff(
+            @PathVariable String id,
+            @RequestParam("from") int from,
+            @RequestParam("to") int to) {
+        return service.diff(id, from, to);
+    }
+
+    @GetMapping("/{id}/versions/{version}")
+    public AgentVersionResponse getVersion(
+            @PathVariable String id, @PathVariable int version) {
+        return service.getVersion(id, version);
+    }
+
+    @PostMapping("/{id}/versions/{version}/restore")
+    public AgentResponse restore(@PathVariable String id, @PathVariable int version) {
+        return service.restore(id, version);
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package io.agentflow.api.controller;
 
 import io.agentflow.api.service.AgentNameConflictException;
 import io.agentflow.api.service.AgentNotFoundException;
+import io.agentflow.api.service.AgentVersionNotFoundException;
 import io.agentflow.api.service.RunConflictException;
 import io.agentflow.api.service.RunNotFoundException;
 import java.util.Map;
@@ -19,6 +20,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AgentNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleAgentNotFound(AgentNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("detail", ex.getMessage()));
+    }
+
+    @ExceptionHandler(AgentVersionNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleAgentVersionNotFound(
+            AgentVersionNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("detail", ex.getMessage()));
     }
 

--- a/backend-java/src/main/java/io/agentflow/api/dto/AgentUpdateRequest.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/AgentUpdateRequest.java
@@ -1,0 +1,77 @@
+package io.agentflow.api.dto;
+
+import java.util.Map;
+
+public class AgentUpdateRequest {
+
+    private String name;
+    private String description;
+    private String adapter;
+    private Map<String, Object> config;
+    private String note;
+
+    private boolean nameSet;
+    private boolean descriptionSet;
+    private boolean adapterSet;
+    private boolean configSet;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+        this.nameSet = true;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+        this.descriptionSet = true;
+    }
+
+    public String getAdapter() {
+        return adapter;
+    }
+
+    public void setAdapter(String adapter) {
+        this.adapter = adapter;
+        this.adapterSet = true;
+    }
+
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+        this.config = config;
+        this.configSet = true;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    public boolean isNameSet() {
+        return nameSet;
+    }
+
+    public boolean isDescriptionSet() {
+        return descriptionSet;
+    }
+
+    public boolean isAdapterSet() {
+        return adapterSet;
+    }
+
+    public boolean isConfigSet() {
+        return configSet;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/AgentVersionDiffResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/AgentVersionDiffResponse.java
@@ -1,0 +1,52 @@
+package io.agentflow.api.dto;
+
+import java.util.Map;
+
+public class AgentVersionDiffResponse {
+
+    private int fromVersion;
+    private int toVersion;
+    private Map<String, Object> adapter;
+    private Map<String, Object> description;
+    private Map<String, Object> config;
+
+    public int getFromVersion() {
+        return fromVersion;
+    }
+
+    public void setFromVersion(int fromVersion) {
+        this.fromVersion = fromVersion;
+    }
+
+    public int getToVersion() {
+        return toVersion;
+    }
+
+    public void setToVersion(int toVersion) {
+        this.toVersion = toVersion;
+    }
+
+    public Map<String, Object> getAdapter() {
+        return adapter;
+    }
+
+    public void setAdapter(Map<String, Object> adapter) {
+        this.adapter = adapter;
+    }
+
+    public Map<String, Object> getDescription() {
+        return description;
+    }
+
+    public void setDescription(Map<String, Object> description) {
+        this.description = description;
+    }
+
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+        this.config = config;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/AgentVersionResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/AgentVersionResponse.java
@@ -1,30 +1,30 @@
 package io.agentflow.api.dto;
 
-import io.agentflow.api.entity.AgentEntity;
+import io.agentflow.api.entity.AgentVersionEntity;
 import java.time.Instant;
 import java.util.Map;
 
-public class AgentResponse {
+public class AgentVersionResponse {
 
     private String id;
-    private String name;
+    private String agentId;
+    private int version;
     private String description;
     private String adapter;
     private Map<String, Object> config;
-    private int version;
+    private String note;
     private Instant createdAt;
-    private Instant updatedAt;
 
-    public static AgentResponse fromEntity(AgentEntity entity) {
-        AgentResponse dto = new AgentResponse();
+    public static AgentVersionResponse fromEntity(AgentVersionEntity entity) {
+        AgentVersionResponse dto = new AgentVersionResponse();
         dto.id = entity.getId();
-        dto.name = entity.getName();
+        dto.agentId = entity.getAgentId();
+        dto.version = entity.getVersion();
         dto.description = entity.getDescription();
         dto.adapter = entity.getAdapter();
         dto.config = entity.getConfig();
-        dto.version = entity.getVersion();
+        dto.note = entity.getNote();
         dto.createdAt = entity.getCreatedAt();
-        dto.updatedAt = entity.getUpdatedAt();
         return dto;
     }
 
@@ -32,8 +32,12 @@ public class AgentResponse {
         return id;
     }
 
-    public String getName() {
-        return name;
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public int getVersion() {
+        return version;
     }
 
     public String getDescription() {
@@ -48,15 +52,11 @@ public class AgentResponse {
         return config;
     }
 
-    public int getVersion() {
-        return version;
+    public String getNote() {
+        return note;
     }
 
     public Instant getCreatedAt() {
         return createdAt;
-    }
-
-    public Instant getUpdatedAt() {
-        return updatedAt;
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/entity/AgentVersionEntity.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/AgentVersionEntity.java
@@ -8,33 +8,42 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
 @Entity
-@Table(name = "agents")
-public class AgentEntity {
+@Table(
+        name = "agent_versions",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uq_agent_versions_agent_version",
+                        columnNames = {"agent_id", "version"}))
+public class AgentVersionEntity {
 
     @Id
     @Column(length = 26)
     private String id;
 
-    @Column(nullable = false, unique = true, length = 128)
-    private String name;
+    @Column(name = "agent_id", nullable = false, length = 26)
+    private String agentId;
+
+    @Column(nullable = false)
+    private int version;
 
     @Column(length = 1024)
     private String description;
 
     @Column(nullable = false, length = 64)
-    private String adapter = "echo";
+    private String adapter;
 
     @Column(name = "config", nullable = false, columnDefinition = "TEXT")
     @Convert(converter = JsonMapConverter.class)
     private Map<String, Object> config = new HashMap<>();
 
-    @Column(nullable = false)
-    private int version = 1;
+    @Column(length = 512)
+    private String note;
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
@@ -67,12 +76,20 @@ public class AgentEntity {
         this.id = id;
     }
 
-    public String getName() {
-        return name;
+    public String getAgentId() {
+        return agentId;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public void setAgentId(String agentId) {
+        this.agentId = agentId;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
     }
 
     public String getDescription() {
@@ -99,12 +116,12 @@ public class AgentEntity {
         this.config = config == null ? new HashMap<>() : config;
     }
 
-    public int getVersion() {
-        return version;
+    public String getNote() {
+        return note;
     }
 
-    public void setVersion(int version) {
-        this.version = version;
+    public void setNote(String note) {
+        this.note = note;
     }
 
     public Instant getCreatedAt() {

--- a/backend-java/src/main/java/io/agentflow/api/repository/AgentVersionRepository.java
+++ b/backend-java/src/main/java/io/agentflow/api/repository/AgentVersionRepository.java
@@ -1,0 +1,13 @@
+package io.agentflow.api.repository;
+
+import io.agentflow.api.entity.AgentVersionEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgentVersionRepository extends JpaRepository<AgentVersionEntity, String> {
+
+    List<AgentVersionEntity> findByAgentIdOrderByVersionDesc(String agentId);
+
+    Optional<AgentVersionEntity> findByAgentIdAndVersion(String agentId, int version);
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/AgentService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/AgentService.java
@@ -2,10 +2,19 @@ package io.agentflow.api.service;
 
 import io.agentflow.api.dto.AgentCreateRequest;
 import io.agentflow.api.dto.AgentResponse;
+import io.agentflow.api.dto.AgentUpdateRequest;
+import io.agentflow.api.dto.AgentVersionDiffResponse;
+import io.agentflow.api.dto.AgentVersionResponse;
 import io.agentflow.api.entity.AgentEntity;
+import io.agentflow.api.entity.AgentVersionEntity;
 import io.agentflow.api.repository.AgentRepository;
+import io.agentflow.api.repository.AgentVersionRepository;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeSet;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,9 +23,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class AgentService {
 
     private final AgentRepository repository;
+    private final AgentVersionRepository versionRepository;
 
-    public AgentService(AgentRepository repository) {
+    public AgentService(AgentRepository repository, AgentVersionRepository versionRepository) {
         this.repository = repository;
+        this.versionRepository = versionRepository;
     }
 
     @Transactional
@@ -29,8 +40,10 @@ public class AgentService {
         entity.setDescription(req.getDescription());
         entity.setAdapter(req.getAdapter());
         entity.setConfig(new HashMap<>(req.getConfig()));
+        entity.setVersion(1);
         try {
             AgentEntity saved = repository.save(entity);
+            versionRepository.save(snapshot(saved, "initial"));
             return AgentResponse.fromEntity(saved);
         } catch (DataIntegrityViolationException e) {
             throw new AgentNameConflictException(req.getName());
@@ -54,5 +67,185 @@ public class AgentService {
     @Transactional(readOnly = true)
     public AgentEntity getEntity(String id) {
         return repository.findById(id).orElseThrow(() -> new AgentNotFoundException(id));
+    }
+
+    @Transactional
+    public AgentResponse update(String id, AgentUpdateRequest req) {
+        AgentEntity agent = getEntity(id);
+
+        if (req.isNameSet() && req.getName() != null) {
+            agent.setName(req.getName());
+        }
+
+        String newDescription =
+                req.isDescriptionSet() ? req.getDescription() : agent.getDescription();
+        String newAdapter =
+                req.isAdapterSet() && req.getAdapter() != null
+                        ? req.getAdapter()
+                        : agent.getAdapter();
+        Map<String, Object> newConfig =
+                req.isConfigSet() && req.getConfig() != null
+                        ? new HashMap<>(req.getConfig())
+                        : new HashMap<>(agent.getConfig());
+
+        boolean bump =
+                (req.isDescriptionSet() && !Objects.equals(newDescription, agent.getDescription()))
+                        || (req.isAdapterSet() && !Objects.equals(newAdapter, agent.getAdapter()))
+                        || (req.isConfigSet() && !Objects.equals(newConfig, agent.getConfig()));
+
+        if (req.isDescriptionSet()) {
+            agent.setDescription(req.getDescription());
+        }
+        if (req.isAdapterSet() && req.getAdapter() != null) {
+            agent.setAdapter(req.getAdapter());
+        }
+        if (req.isConfigSet() && req.getConfig() != null) {
+            agent.setConfig(new HashMap<>(req.getConfig()));
+        }
+
+        try {
+            if (bump) {
+                agent.setVersion(agent.getVersion() + 1);
+                AgentEntity saved = repository.save(agent);
+                versionRepository.save(snapshot(saved, req.getNote()));
+                return AgentResponse.fromEntity(saved);
+            }
+            return AgentResponse.fromEntity(repository.save(agent));
+        } catch (DataIntegrityViolationException e) {
+            throw new AgentNameConflictException(
+                    req.isNameSet() ? req.getName() : agent.getName());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<AgentVersionResponse> listVersions(String agentId) {
+        getEntity(agentId);
+        return versionRepository.findByAgentIdOrderByVersionDesc(agentId).stream()
+                .map(AgentVersionResponse::fromEntity)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AgentVersionResponse getVersion(String agentId, int version) {
+        getEntity(agentId);
+        return versionRepository
+                .findByAgentIdAndVersion(agentId, version)
+                .map(AgentVersionResponse::fromEntity)
+                .orElseThrow(() -> new AgentVersionNotFoundException(version));
+    }
+
+    @Transactional(readOnly = true)
+    public AgentVersionDiffResponse diff(String agentId, int fromVersion, int toVersion) {
+        getEntity(agentId);
+        AgentVersionEntity left =
+                versionRepository
+                        .findByAgentIdAndVersion(agentId, fromVersion)
+                        .orElseThrow(() -> new AgentVersionNotFoundException(fromVersion));
+        AgentVersionEntity right =
+                versionRepository
+                        .findByAgentIdAndVersion(agentId, toVersion)
+                        .orElseThrow(() -> new AgentVersionNotFoundException(toVersion));
+
+        AgentVersionDiffResponse diff = new AgentVersionDiffResponse();
+        diff.setFromVersion(fromVersion);
+        diff.setToVersion(toVersion);
+        if (!Objects.equals(left.getAdapter(), right.getAdapter())) {
+            diff.setAdapter(Map.of("from", left.getAdapter(), "to", right.getAdapter()));
+        }
+        if (!Objects.equals(left.getDescription(), right.getDescription())) {
+            Map<String, Object> description = new LinkedHashMap<>();
+            description.put("from", left.getDescription());
+            description.put("to", right.getDescription());
+            diff.setDescription(description);
+        }
+        diff.setConfig(configDiff(left.getConfig(), right.getConfig()));
+        return diff;
+    }
+
+    @Transactional
+    public AgentResponse restore(String agentId, int version) {
+        AgentEntity agent = getEntity(agentId);
+        AgentVersionEntity snap =
+                versionRepository
+                        .findByAgentIdAndVersion(agentId, version)
+                        .orElseThrow(() -> new AgentVersionNotFoundException(version));
+
+        if (Objects.equals(agent.getAdapter(), snap.getAdapter())
+                && Objects.equals(agent.getConfig(), snap.getConfig())
+                && Objects.equals(agent.getDescription(), snap.getDescription())) {
+            return AgentResponse.fromEntity(agent);
+        }
+
+        agent.setAdapter(snap.getAdapter());
+        agent.setConfig(new HashMap<>(snap.getConfig()));
+        agent.setDescription(snap.getDescription());
+        agent.setVersion(agent.getVersion() + 1);
+        AgentEntity saved = repository.save(agent);
+        versionRepository.save(snapshot(saved, "restored from v" + version));
+        return AgentResponse.fromEntity(saved);
+    }
+
+    private static AgentVersionEntity snapshot(AgentEntity agent, String note) {
+        AgentVersionEntity row = new AgentVersionEntity();
+        row.setAgentId(agent.getId());
+        row.setVersion(agent.getVersion());
+        row.setDescription(agent.getDescription());
+        row.setAdapter(agent.getAdapter());
+        row.setConfig(new HashMap<>(agent.getConfig()));
+        row.setNote(note);
+        return row;
+    }
+
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> configDiff(Map<String, Object> left, Map<String, Object> right) {
+        Map<String, Object> added = new LinkedHashMap<>();
+        Map<String, Object> removed = new LinkedHashMap<>();
+        Map<String, Object> changed = new LinkedHashMap<>();
+        walk(
+                left == null ? Map.of() : left,
+                right == null ? Map.of() : right,
+                "",
+                added,
+                removed,
+                changed);
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("added", added);
+        out.put("removed", removed);
+        out.put("changed", changed);
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void walk(
+            Object left,
+            Object right,
+            String path,
+            Map<String, Object> added,
+            Map<String, Object> removed,
+            Map<String, Object> changed) {
+        if (left instanceof Map<?, ?> leftMap && right instanceof Map<?, ?> rightMap) {
+            TreeSet<String> keys = new TreeSet<>();
+            leftMap.keySet().forEach(k -> keys.add(String.valueOf(k)));
+            rightMap.keySet().forEach(k -> keys.add(String.valueOf(k)));
+            for (String key : keys) {
+                String child = path.isEmpty() ? key : path + "." + key;
+                boolean inLeft = leftMap.containsKey(key);
+                boolean inRight = rightMap.containsKey(key);
+                if (!inLeft) {
+                    added.put(child, rightMap.get(key));
+                } else if (!inRight) {
+                    removed.put(child, leftMap.get(key));
+                } else {
+                    walk(leftMap.get(key), rightMap.get(key), child, added, removed, changed);
+                }
+            }
+            return;
+        }
+        if (!Objects.equals(left, right)) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("from", left);
+            entry.put("to", right);
+            changed.put(path.isEmpty() ? "" : path, entry);
+        }
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/service/AgentVersionNotFoundException.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/AgentVersionNotFoundException.java
@@ -1,0 +1,12 @@
+package io.agentflow.api.service;
+
+public class AgentVersionNotFoundException extends RuntimeException {
+
+    public AgentVersionNotFoundException(String agentId, int version) {
+        super("Agent version not found: " + agentId + "@v" + version);
+    }
+
+    public AgentVersionNotFoundException(int version) {
+        super("Agent version not found: " + version);
+    }
+}

--- a/backend/alembic/versions/0003_agent_versions.py
+++ b/backend/alembic/versions/0003_agent_versions.py
@@ -1,0 +1,84 @@
+"""Add agent.version and agent_versions history table."""
+
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from ulid import ULID
+
+revision = "0003_agent_versions"
+down_revision = "0002_step_cost_usd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.create_table(
+        "agent_versions",
+        sa.Column("id", sa.String(26), primary_key=True),
+        sa.Column(
+            "agent_id",
+            sa.String(26),
+            sa.ForeignKey("agents.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("description", sa.String(1024), nullable=True),
+        sa.Column("adapter", sa.String(64), nullable=False),
+        sa.Column("config", sa.JSON(), nullable=False),
+        sa.Column("note", sa.String(512), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "agent_id", "version", name="uq_agent_versions_agent_version"
+        ),
+    )
+    op.create_index(
+        "ix_agent_versions_agent_id", "agent_versions", ["agent_id"]
+    )
+
+    conn = op.get_bind()
+    agents = conn.execute(
+        sa.text(
+            "SELECT id, description, adapter, config, created_at, updated_at "
+            "FROM agents"
+        )
+    ).mappings()
+    insert = sa.text(
+        "INSERT INTO agent_versions "
+        "(id, agent_id, version, description, adapter, config, note, "
+        "created_at, updated_at) "
+        "VALUES (:id, :agent_id, 1, :description, :adapter, :config, "
+        ":note, :created_at, :updated_at)"
+    )
+    for row in agents:
+        config = row["config"]
+        if isinstance(config, str):
+            config = json.loads(config)
+        conn.execute(
+            insert,
+            {
+                "id": str(ULID()),
+                "agent_id": row["id"],
+                "description": row["description"],
+                "adapter": row["adapter"],
+                "config": json.dumps(config) if conn.dialect.name == "sqlite" else config,
+                "note": "initial",
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+            },
+        )
+
+    op.alter_column("agents", "version", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_versions_agent_id", table_name="agent_versions")
+    op.drop_table("agent_versions")
+    op.drop_column("agents", "version")

--- a/backend/app/api/v1/agents.py
+++ b/backend/app/api/v1/agents.py
@@ -1,11 +1,25 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_session
 from app.models import Agent
-from app.schemas.agent import AgentCreate, AgentRead
+from app.models.agent import AgentVersion
+from app.schemas.agent import (
+    AgentCreate,
+    AgentRead,
+    AgentUpdate,
+    AgentVersionDiff,
+    AgentVersionRead,
+)
+from app.services.agent_versions import (
+    definition_changed,
+    get_agent_version,
+    list_agent_versions,
+    snapshot_agent,
+    version_diff,
+)
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
@@ -19,9 +33,12 @@ async def create_agent(
         description=payload.description,
         adapter=payload.adapter,
         config=payload.config,
+        version=1,
     )
     session.add(agent)
     try:
+        await session.flush()
+        session.add(snapshot_agent(agent, note="initial"))
         await session.commit()
     except IntegrityError as exc:
         await session.rollback()
@@ -46,4 +63,147 @@ async def get_agent(
     agent = await session.get(Agent, agent_id)
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
+@router.patch("/{agent_id}", response_model=AgentRead)
+async def update_agent(
+    agent_id: str,
+    payload: AgentUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> Agent:
+    agent = await session.get(Agent, agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    fields_set = payload.model_fields_set
+    if "name" in fields_set and payload.name is not None:
+        agent.name = payload.name
+
+    new_description = (
+        payload.description if "description" in fields_set else agent.description
+    )
+    new_adapter = payload.adapter if "adapter" in fields_set else agent.adapter
+    new_config = (
+        dict(payload.config) if "config" in fields_set and payload.config is not None
+        else dict(agent.config or {})
+    )
+
+    bump = definition_changed(
+        agent,
+        description=new_description,
+        adapter=new_adapter or agent.adapter,
+        config=new_config,
+        description_set="description" in fields_set,
+        adapter_set="adapter" in fields_set,
+        config_set="config" in fields_set,
+    )
+
+    if "description" in fields_set:
+        agent.description = payload.description
+    if "adapter" in fields_set and payload.adapter is not None:
+        agent.adapter = payload.adapter
+    if "config" in fields_set and payload.config is not None:
+        agent.config = dict(payload.config)
+
+    if bump:
+        agent.version = int(agent.version or 1) + 1
+        session.add(snapshot_agent(agent, note=payload.note))
+
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Agent name already exists: {payload.name}",
+        ) from exc
+    await session.refresh(agent)
+    return agent
+
+
+@router.get("/{agent_id}/versions", response_model=list[AgentVersionRead])
+async def list_versions(
+    agent_id: str, session: AsyncSession = Depends(get_session)
+) -> list[AgentVersion]:
+    agent = await session.get(Agent, agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return await list_agent_versions(session, agent_id)
+
+
+@router.get(
+    "/{agent_id}/versions/diff",
+    response_model=AgentVersionDiff,
+)
+async def diff_versions(
+    agent_id: str,
+    from_version: int = Query(..., alias="from", ge=1),
+    to_version: int = Query(..., alias="to", ge=1),
+    session: AsyncSession = Depends(get_session),
+) -> AgentVersionDiff:
+    agent = await session.get(Agent, agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    left = await get_agent_version(session, agent_id, from_version)
+    right = await get_agent_version(session, agent_id, to_version)
+    if left is None or right is None:
+        missing = from_version if left is None else to_version
+        raise HTTPException(
+            status_code=404, detail=f"Agent version not found: {missing}"
+        )
+    return AgentVersionDiff.model_validate(version_diff(left, right))
+
+
+@router.get(
+    "/{agent_id}/versions/{version}",
+    response_model=AgentVersionRead,
+)
+async def get_version(
+    agent_id: str,
+    version: int,
+    session: AsyncSession = Depends(get_session),
+) -> AgentVersion:
+    agent = await session.get(Agent, agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    row = await get_agent_version(session, agent_id, version)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Agent version not found")
+    return row
+
+
+@router.post(
+    "/{agent_id}/versions/{version}/restore",
+    response_model=AgentRead,
+)
+async def restore_version(
+    agent_id: str,
+    version: int,
+    session: AsyncSession = Depends(get_session),
+) -> Agent:
+    """Restore adapter/config/description from a snapshot as a new version."""
+    agent = await session.get(Agent, agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    snap = await get_agent_version(session, agent_id, version)
+    if snap is None:
+        raise HTTPException(status_code=404, detail="Agent version not found")
+
+    if (
+        agent.adapter == snap.adapter
+        and (agent.config or {}) == (snap.config or {})
+        and agent.description == snap.description
+    ):
+        return agent
+
+    agent.adapter = snap.adapter
+    agent.config = dict(snap.config or {})
+    agent.description = snap.description
+    agent.version = int(agent.version or 1) + 1
+    session.add(
+        snapshot_agent(agent, note=f"restored from v{version}")
+    )
+    await session.commit()
+    await session.refresh(agent)
     return agent

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,8 +1,9 @@
-from app.models.agent import Agent
+from app.models.agent import Agent, AgentVersion
 from app.models.run import Checkpoint, Message, Run, RunStatus, Step, ToolCall
 
 __all__ = [
     "Agent",
+    "AgentVersion",
     "Checkpoint",
     "Message",
     "Run",

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from sqlalchemy import JSON, String
+from sqlalchemy import JSON, ForeignKey, Index, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ulid import ULID
 
@@ -18,6 +18,9 @@ class Agent(Base):
     adapter that knows how to run it, and an opaque config blob. The adapter
     decides how to interpret `config` (graph definition, role prompts, tool
     list, etc.).
+
+    ``version`` is a monotonic integer that bumps whenever adapter / config /
+    description change; each bump is also stored in ``agent_versions``.
     """
 
     __tablename__ = "agents"
@@ -27,8 +30,36 @@ class Agent(Base):
     description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     adapter: Mapped[str] = mapped_column(String(64), default="echo")
     config: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
 
     runs: Mapped[list["Run"]] = relationship(  # noqa: F821 -- forward ref
         back_populates="agent",
         cascade="all, delete-orphan",
     )
+    versions: Mapped[list["AgentVersion"]] = relationship(
+        back_populates="agent",
+        order_by="AgentVersion.version",
+        cascade="all, delete-orphan",
+    )
+
+
+class AgentVersion(Base):
+    """Immutable snapshot of an agent definition at a given version number."""
+
+    __tablename__ = "agent_versions"
+    __table_args__ = (
+        UniqueConstraint("agent_id", "version", name="uq_agent_versions_agent_version"),
+        Index("ix_agent_versions_agent_id", "agent_id"),
+    )
+
+    id: Mapped[str] = mapped_column(String(26), primary_key=True, default=_ulid)
+    agent_id: Mapped[str] = mapped_column(
+        ForeignKey("agents.id", ondelete="CASCADE"), nullable=False
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    adapter: Mapped[str] = mapped_column(String(64), nullable=False)
+    config: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    note: Mapped[str | None] = mapped_column(String(512), nullable=True)
+
+    agent: Mapped[Agent] = relationship(back_populates="versions")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,4 +1,10 @@
-from app.schemas.agent import AgentCreate, AgentRead
+from app.schemas.agent import (
+    AgentCreate,
+    AgentRead,
+    AgentUpdate,
+    AgentVersionDiff,
+    AgentVersionRead,
+)
 from app.schemas.run import (
     CheckpointRead,
     MessageRead,
@@ -13,6 +19,9 @@ from app.schemas.run import (
 __all__ = [
     "AgentCreate",
     "AgentRead",
+    "AgentUpdate",
+    "AgentVersionDiff",
+    "AgentVersionRead",
     "CheckpointRead",
     "MessageRead",
     "RunCreate",

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -11,6 +11,20 @@ class AgentCreate(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
 
 
+class AgentUpdate(BaseModel):
+    """Partial update. Bumps ``version`` when adapter/config/description change."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=128)
+    description: str | None = None
+    adapter: str | None = None
+    config: dict[str, Any] | None = None
+    note: str | None = Field(
+        default=None,
+        max_length=512,
+        description="Optional note stored on the new version snapshot.",
+    )
+
+
 class AgentRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -19,5 +33,27 @@ class AgentRead(BaseModel):
     description: str | None
     adapter: str
     config: dict[str, Any]
+    version: int
     created_at: datetime
     updated_at: datetime
+
+
+class AgentVersionRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    agent_id: str
+    version: int
+    description: str | None
+    adapter: str
+    config: dict[str, Any]
+    note: str | None
+    created_at: datetime
+
+
+class AgentVersionDiff(BaseModel):
+    from_version: int
+    to_version: int
+    adapter: dict[str, Any] | None = None
+    description: dict[str, Any] | None = None
+    config: dict[str, Any]

--- a/backend/app/services/agent_versions.py
+++ b/backend/app/services/agent_versions.py
@@ -1,0 +1,120 @@
+"""Agent version snapshots and config diff helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent import Agent, AgentVersion
+
+
+def snapshot_agent(
+    agent: Agent,
+    *,
+    note: str | None = None,
+) -> AgentVersion:
+    """Build an ``AgentVersion`` row matching the agent's current fields."""
+    return AgentVersion(
+        agent_id=agent.id,
+        version=agent.version,
+        description=agent.description,
+        adapter=agent.adapter,
+        config=dict(agent.config or {}),
+        note=note,
+    )
+
+
+async def get_agent_version(
+    session: AsyncSession, agent_id: str, version: int
+) -> AgentVersion | None:
+    result = await session.execute(
+        select(AgentVersion).where(
+            AgentVersion.agent_id == agent_id,
+            AgentVersion.version == version,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_agent_versions(
+    session: AsyncSession, agent_id: str
+) -> list[AgentVersion]:
+    result = await session.execute(
+        select(AgentVersion)
+        .where(AgentVersion.agent_id == agent_id)
+        .order_by(AgentVersion.version.desc())
+    )
+    return list(result.scalars())
+
+
+def definition_changed(
+    agent: Agent,
+    *,
+    description: str | None,
+    adapter: str,
+    config: dict[str, Any],
+    description_set: bool,
+    adapter_set: bool,
+    config_set: bool,
+) -> bool:
+    """Return True when adapter / config / description would change."""
+    if description_set and description != agent.description:
+        return True
+    if adapter_set and adapter != agent.adapter:
+        return True
+    if config_set and config != (agent.config or {}):
+        return True
+    return False
+
+
+def config_diff(
+    left: dict[str, Any] | None, right: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Shallow-recursive dict diff with dotted paths for nested objects."""
+    left = left or {}
+    right = right or {}
+    added: dict[str, Any] = {}
+    removed: dict[str, Any] = {}
+    changed: dict[str, dict[str, Any]] = {}
+
+    def walk(a: Any, b: Any, path: str) -> None:
+        if isinstance(a, dict) and isinstance(b, dict):
+            keys = set(a) | set(b)
+            for key in sorted(keys):
+                child = f"{path}.{key}" if path else key
+                if key not in a:
+                    added[child] = b[key]
+                elif key not in b:
+                    removed[child] = a[key]
+                else:
+                    walk(a[key], b[key], child)
+            return
+        if a != b:
+            if path:
+                changed[path] = {"from": a, "to": b}
+            else:
+                changed[""] = {"from": a, "to": b}
+
+    walk(left, right, "")
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+def version_diff(from_ver: AgentVersion, to_ver: AgentVersion) -> dict[str, Any]:
+    adapter_change = None
+    if from_ver.adapter != to_ver.adapter:
+        adapter_change = {"from": from_ver.adapter, "to": to_ver.adapter}
+    description_change = None
+    if from_ver.description != to_ver.description:
+        description_change = {
+            "from": from_ver.description,
+            "to": to_ver.description,
+        }
+    return {
+        "from_version": from_ver.version,
+        "to_version": to_ver.version,
+        "adapter": adapter_change,
+        "description": description_change,
+        "config": config_diff(from_ver.config, to_ver.config),
+    }

--- a/backend/tests/test_agent_versions.py
+++ b/backend/tests/test_agent_versions.py
@@ -1,0 +1,108 @@
+"""Agent version management tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_agent_starts_at_v1(client):
+    resp = await client.post(
+        "/v1/agents",
+        json={"name": "ver-bot", "adapter": "echo", "config": {"delay": 0}},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["version"] == 1
+
+    versions = await client.get(f"/v1/agents/{body['id']}/versions")
+    assert versions.status_code == 200
+    rows = versions.json()
+    assert len(rows) == 1
+    assert rows[0]["version"] == 1
+    assert rows[0]["note"] == "initial"
+    assert rows[0]["config"] == {"delay": 0}
+
+
+@pytest.mark.asyncio
+async def test_update_bumps_version_and_diff(client):
+    created = await client.post(
+        "/v1/agents",
+        json={
+            "name": "diff-bot",
+            "adapter": "echo",
+            "config": {"model": "a", "tools": ["echo"]},
+        },
+    )
+    agent_id = created.json()["id"]
+
+    updated = await client.patch(
+        f"/v1/agents/{agent_id}",
+        json={
+            "adapter": "langgraph",
+            "config": {"model": "b", "tools": ["echo"], "stream_tokens": True},
+            "note": "switch to langgraph",
+        },
+    )
+    assert updated.status_code == 200
+    assert updated.json()["version"] == 2
+    assert updated.json()["adapter"] == "langgraph"
+
+    v2 = await client.get(f"/v1/agents/{agent_id}/versions/2")
+    assert v2.status_code == 200
+    assert v2.json()["note"] == "switch to langgraph"
+
+    diff = await client.get(
+        f"/v1/agents/{agent_id}/versions/diff",
+        params={"from": 1, "to": 2},
+    )
+    assert diff.status_code == 200
+    body = diff.json()
+    assert body["adapter"] == {"from": "echo", "to": "langgraph"}
+    assert body["config"]["changed"]["model"] == {"from": "a", "to": "b"}
+    assert body["config"]["added"]["stream_tokens"] is True
+
+
+@pytest.mark.asyncio
+async def test_name_only_update_does_not_bump_version(client):
+    created = await client.post(
+        "/v1/agents",
+        json={"name": "rename-me", "adapter": "echo", "config": {}},
+    )
+    agent_id = created.json()["id"]
+
+    updated = await client.patch(
+        f"/v1/agents/{agent_id}",
+        json={"name": "renamed"},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["name"] == "renamed"
+    assert updated.json()["version"] == 1
+
+    versions = await client.get(f"/v1/agents/{agent_id}/versions")
+    assert len(versions.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_restore_creates_new_version(client):
+    created = await client.post(
+        "/v1/agents",
+        json={"name": "restore-bot", "adapter": "echo", "config": {"x": 1}},
+    )
+    agent_id = created.json()["id"]
+
+    await client.patch(
+        f"/v1/agents/{agent_id}",
+        json={"config": {"x": 2}, "adapter": "langgraph"},
+    )
+
+    restored = await client.post(f"/v1/agents/{agent_id}/versions/1/restore")
+    assert restored.status_code == 200
+    body = restored.json()
+    assert body["version"] == 3
+    assert body["adapter"] == "echo"
+    assert body["config"] == {"x": 1}
+
+    versions = await client.get(f"/v1/agents/{agent_id}/versions")
+    notes = {row["version"]: row["note"] for row in versions.json()}
+    assert notes[3] == "restored from v1"

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -54,6 +54,44 @@ Response: `Agent[]` ordered by `created_at` descending.
 
 Response: `Agent`. 404 if missing.
 
+### `PATCH /v1/agents/{id}` → 200
+
+Partial update. When `adapter`, `config`, or `description` change, `version`
+increments and a row is appended to `agent_versions`. Name-only updates do
+not bump the version. Optional `note` is stored on the new snapshot.
+
+Request (all fields optional):
+
+```json
+{
+  "name": "writer-v2",
+  "description": "optional",
+  "adapter": "langgraph",
+  "config": { "model": "openai/gpt-4o-mini" },
+  "note": "enable langgraph"
+}
+```
+
+Response: updated `Agent`. 404 if missing; 409 if `name` collides.
+
+### `GET /v1/agents/{id}/versions` → 200
+
+Response: `AgentVersion[]` ordered by `version` descending.
+
+### `GET /v1/agents/{id}/versions/{version}` → 200
+
+Response: `AgentVersion`. 404 if agent or version missing.
+
+### `GET /v1/agents/{id}/versions/diff?from=1&to=2` → 200
+
+Response: `AgentVersionDiff` comparing two snapshots (adapter / description /
+config added·removed·changed).
+
+### `POST /v1/agents/{id}/versions/{version}/restore` → 200
+
+Copy the snapshot's adapter/config/description onto the live agent as a **new**
+version (does not delete history). No-op (no bump) when already identical.
+
 ### `POST /v1/runs` → 202
 
 Request:
@@ -182,8 +220,40 @@ before `step.completed`:
   description: string | null;
   adapter: string;
   config: Record<string, unknown>;
+  version: number;
   created_at: string;
   updated_at: string;
+}
+```
+
+### `AgentVersion`
+
+```ts
+{
+  id: string;
+  agent_id: string;
+  version: number;
+  description: string | null;
+  adapter: string;
+  config: Record<string, unknown>;
+  note: string | null;
+  created_at: string;
+}
+```
+
+### `AgentVersionDiff`
+
+```ts
+{
+  from_version: number;
+  to_version: number;
+  adapter: { from: string; to: string } | null;
+  description: { from: string | null; to: string | null } | null;
+  config: {
+    added: Record<string, unknown>;
+    removed: Record<string, unknown>;
+    changed: Record<string, { from: unknown; to: unknown }>;
+  };
 }
 ```
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -9,6 +9,7 @@ agent system.
 ```mermaid
 erDiagram
     Agent ||--o{ Run : has
+    Agent ||--o{ AgentVersion : versions
     Run ||--o{ Step : has
     Run ||--o{ Message : has
     Run ||--o{ Checkpoint : has
@@ -20,6 +21,15 @@ erDiagram
         string name UK
         string adapter
         json config
+        int version
+    }
+    AgentVersion {
+        string id PK
+        string agent_id FK
+        int version
+        string adapter
+        json config
+        string note
     }
     Run {
         string id PK
@@ -93,9 +103,9 @@ stateDiagram-v2
 
 ## Design notes
 
-- **IDs are ULIDs** (26-character strings). They are sortable by time, easy
-  to log, and safer than auto-increment ids when the runtime fans out to
-  multiple workers.
+- **`Agent.version`** is a monotonic integer. Each bump also writes an
+  immutable ``agent_versions`` snapshot (adapter + config + description).
+  Restore creates a new version rather than rewriting history.
 - **`metadata` is a JSON column** named `metadata_` in Python because
   `metadata` is reserved on `DeclarativeBase`. The column on disk is still
   `metadata`.
@@ -118,3 +128,5 @@ stateDiagram-v2
 | `ix_messages_run_index` | stream messages in order |
 | `ix_tool_calls_step` | render tool calls inside a step |
 | `ix_checkpoints_run_index` | replay from the latest checkpoint |
+| `ix_agent_versions_agent_id` | list version history for an agent |
+| `uq_agent_versions_agent_version` | one snapshot per (agent, version) |

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -50,7 +50,7 @@
 - [ ] MCP tool adapter
 - [ ] OpenAPI 规范 + Python/TypeScript SDK 自动生成
 - [ ] Webhook 出站事件（`run.completed` 等）
-- [ ] Agent 版本管理与配置 diff
+- [x] Agent 版本管理与配置 diff
 
 **验收：** 新 adapter 以包形式发布；SDK 覆盖 create-run + subscribe-events；MCP 调用写入 ToolCall。
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Agent, Run } from "./types";
+import type { Agent, AgentVersion, AgentVersionDiff, Run } from "./types";
 import { normalizeUsage } from "./usage";
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -64,6 +64,32 @@ export const api = {
     request<Agent>("/v1/agents", {
       method: "POST",
       body: JSON.stringify({ adapter: "echo", config: {}, ...body }),
+    }),
+  updateAgent: (
+    id: string,
+    body: {
+      name?: string;
+      description?: string | null;
+      adapter?: string;
+      config?: Record<string, unknown>;
+      note?: string;
+    },
+  ) =>
+    request<Agent>(`/v1/agents/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  listAgentVersions: (id: string) =>
+    request<AgentVersion[]>(`/v1/agents/${id}/versions`),
+  getAgentVersion: (id: string, version: number) =>
+    request<AgentVersion>(`/v1/agents/${id}/versions/${version}`),
+  diffAgentVersions: (id: string, from: number, to: number) =>
+    request<AgentVersionDiff>(
+      `/v1/agents/${id}/versions/diff?from=${from}&to=${to}`,
+    ),
+  restoreAgentVersion: (id: string, version: number) =>
+    request<Agent>(`/v1/agents/${id}/versions/${version}/restore`, {
+      method: "POST",
     }),
 };
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -83,8 +83,32 @@ export interface Agent {
   description: string | null;
   adapter: string;
   config: Record<string, unknown>;
+  version: number;
   created_at: string;
   updated_at: string;
+}
+
+export interface AgentVersion {
+  id: string;
+  agent_id: string;
+  version: number;
+  description: string | null;
+  adapter: string;
+  config: Record<string, unknown>;
+  note: string | null;
+  created_at: string;
+}
+
+export interface AgentVersionDiff {
+  from_version: number;
+  to_version: number;
+  adapter: { from: string; to: string } | null;
+  description: { from: string | null; to: string | null } | null;
+  config: {
+    added: Record<string, unknown>;
+    removed: Record<string, unknown>;
+    changed: Record<string, { from: unknown; to: unknown }>;
+  };
 }
 
 export interface RunEvent {


### PR DESCRIPTION
- Added `version` field to the `agents` table to track changes.
- Created `agent_versions` table to store snapshots of agent configurations.
- Implemented API endpoints for updating agents, listing versions, retrieving specific versions, and comparing version diffs.
- Introduced logic to increment version on configuration changes and store notes for each version snapshot.
- Enhanced tests to cover agent creation, updates, version listing, and restoration of previous versions.