### PR TITLE
feat: add adapter plugin registry via entry points

### DIFF
--- a/backend/app/adapters/__init__.py
+++ b/backend/app/adapters/__init__.py
@@ -19,6 +19,7 @@ from app.adapters.base import (
     get_adapter,
     register_adapter,
 )
+from app.adapters.discovery import AdapterPluginError, load_adapter_plugins
 from app.adapters.echo_adapter import EchoAdapter
 from app.adapters.langgraph_adapter import LangGraphAdapter
 from app.adapters.mcp_client import (
@@ -40,6 +41,7 @@ register_adapter("langgraph", LangGraphAdapter())
 
 __all__ = [
     "AdapterContext",
+    "AdapterPluginError",
     "AdapterToolSurface",
     "EchoAdapter",
     "LangGraphAdapter",
@@ -52,6 +54,7 @@ __all__ = [
     "get_adapter",
     "get_tool",
     "list_tools",
+    "load_adapter_plugins",
     "open_tool_surface",
     "parse_mcp_servers",
     "register_adapter",

--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -9,7 +9,7 @@ sync. Adapters must not import SQLAlchemy or hit the event bus directly.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -197,8 +197,34 @@ _registry: dict[str, OrchestratorAdapter] = {}
 
 
 def register_adapter(name: str, adapter: OrchestratorAdapter) -> None:
+    """Bind `name` to `adapter`.
+
+    The runtime resolves a run's adapter by name and then reads `adapter.name`
+    back to dispatch it (`RunService.start_run`), so names and instances must
+    map one-to-one. Both directions are rejected rather than silently aliased.
+    """
+    if name in _registry:
+        raise ValueError(f"Adapter already registered: {name!r}")
+    for registered_name, registered in _registry.items():
+        if registered is adapter:
+            raise ValueError(
+                f"Adapter instance already registered as {registered_name!r}, "
+                f"cannot also register as {name!r}"
+            )
     adapter.name = name
     _registry[name] = adapter
+
+
+def register_adapters(adapters: Iterable[tuple[str, OrchestratorAdapter]]) -> None:
+    """Register a batch atomically: on any failure the registry is left unchanged."""
+    snapshot = dict(_registry)
+    try:
+        for name, adapter in adapters:
+            register_adapter(name, adapter)
+    except Exception:
+        _registry.clear()
+        _registry.update(snapshot)
+        raise
 
 
 def get_adapter(name: str) -> OrchestratorAdapter:

--- a/backend/app/adapters/discovery.py
+++ b/backend/app/adapters/discovery.py
@@ -1,0 +1,84 @@
+"""Discover adapter packages installed in the worker environment."""
+
+from __future__ import annotations
+
+from importlib import metadata
+from typing import Any
+
+from app.adapters.base import OrchestratorAdapter, register_adapters
+from app.core.logging import get_logger
+
+ENTRY_POINT_GROUP = "agentflow.adapters"
+
+logger = get_logger("adapters")
+
+_plugins_loaded = False
+
+
+class AdapterPluginError(RuntimeError):
+    """Raised when an installed adapter plugin cannot be registered."""
+
+
+def iter_entry_points() -> list[metadata.EntryPoint]:
+    """Adapter entry points advertised by installed packages, ordered deterministically."""
+    return sorted(
+        metadata.entry_points(group=ENTRY_POINT_GROUP),
+        key=lambda entry_point: (entry_point.name, entry_point.value),
+    )
+
+
+def _build_adapter(entry_point: metadata.EntryPoint) -> OrchestratorAdapter:
+    try:
+        factory: Any = entry_point.load()
+    except Exception as exc:
+        raise AdapterPluginError(
+            f"Failed to load adapter plugin {entry_point.name!r} "
+            f"from {entry_point.value!r}"
+        ) from exc
+
+    if not callable(factory):
+        raise AdapterPluginError(
+            f"Adapter plugin {entry_point.name!r} must expose a zero-argument factory"
+        )
+
+    try:
+        adapter = factory()
+    except Exception as exc:
+        raise AdapterPluginError(
+            f"Adapter plugin factory failed for {entry_point.name!r} "
+            f"from {entry_point.value!r}"
+        ) from exc
+
+    if not isinstance(adapter, OrchestratorAdapter):
+        raise AdapterPluginError(
+            f"Adapter plugin {entry_point.name!r} factory must return "
+            "an OrchestratorAdapter"
+        )
+    return adapter
+
+
+def load_adapter_plugins() -> None:
+    """Register installed adapter plugins on top of the built-in ones, once.
+
+    Building a plugin imports third-party code that may register adapters of
+    its own, so name conflicts are only decidable once every factory has run.
+    The batch is therefore registered atomically at the end: any failure aborts
+    startup with the registry left as it was.
+    """
+    global _plugins_loaded
+    if _plugins_loaded:
+        return
+
+    adapters = [
+        (entry_point.name, _build_adapter(entry_point))
+        for entry_point in iter_entry_points()
+    ]
+
+    try:
+        register_adapters(adapters)
+    except ValueError as exc:
+        raise AdapterPluginError(str(exc)) from exc
+
+    _plugins_loaded = True
+    if adapters:
+        logger.info("adapters.plugins_loaded", adapters=[name for name, _ in adapters])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,10 +6,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
-from app.adapters import (  # noqa: F401 -- registers built-in adapters as a side effect
-    EchoAdapter,
-    LangGraphAdapter,
-)
+
+# Importing the package registers the built-in adapters as a side effect.
+from app.adapters import load_adapter_plugins
 from app.api.v1.router import api_router
 from app.core.http_metrics import RedMetricsMiddleware
 from app.core.logging import get_logger, setup_logging
@@ -24,6 +23,7 @@ logger = get_logger("app")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    load_adapter_plugins()
     setup_telemetry()
     # Ensure tables exist for SQLite dev mode. In production with Postgres,
     # `alembic upgrade head` is the source of truth.

--- a/backend/app/worker/runner.py
+++ b/backend/app/worker/runner.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 import asyncio
 import signal
 
-from app.adapters import EchoAdapter, LangGraphAdapter  # noqa: F401 - register
+# Importing the package registers the built-in adapters as a side effect.
+from app.adapters import load_adapter_plugins
 from app.core.config import get_settings
 from app.core.logging import get_logger, setup_logging
 from app.core.telemetry import (
@@ -149,6 +150,7 @@ async def _consume_loop(
 
 async def run_forever() -> None:
     setup_logging()
+    load_adapter_plugins()
     setup_telemetry()
     settings = get_settings()
     concurrency = settings.worker_concurrency

--- a/backend/tests/test_adapter_plugins.py
+++ b/backend/tests/test_adapter_plugins.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Any
+
+import pytest
+
+from app.adapters import base, discovery
+from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
+from app.adapters.discovery import AdapterPluginError, load_adapter_plugins
+from app.models.run import RunStatus
+
+
+class _PluginAdapter(OrchestratorAdapter):
+    async def run(self, ctx: AdapterContext) -> AdapterResult:
+        return AdapterResult(status=RunStatus.SUCCEEDED)
+
+
+def create_plugin_adapter() -> OrchestratorAdapter:
+    """Factory target resolved through a real `EntryPoint.load()`."""
+    return _PluginAdapter()
+
+
+@dataclass
+class _EntryPoint:
+    """Stand-in for targets a real entry point cannot resolve (import errors, non-callables)."""
+
+    name: str
+    value: str
+    target: Any
+
+    def load(self) -> Any:
+        if isinstance(self.target, Exception):
+            raise self.target
+        return self.target
+
+
+@pytest.fixture(autouse=True)
+def isolate_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(base, "_registry", dict(base._registry))
+    monkeypatch.setattr(discovery, "_plugins_loaded", False)
+
+
+def _set_entry_points(monkeypatch: pytest.MonkeyPatch, entry_points: list[Any]) -> None:
+    monkeypatch.setattr(discovery, "iter_entry_points", lambda: entry_points)
+
+
+def test_iter_entry_points_queries_the_declared_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guards the group name and the `entry_points` signature against silent drift."""
+    captured: dict[str, Any] = {}
+
+    def fake_entry_points(**params: Any) -> list[Any]:
+        captured.update(params)
+        return []
+
+    monkeypatch.setattr(discovery.metadata, "entry_points", fake_entry_points)
+
+    assert discovery.iter_entry_points() == []
+    assert captured == {"group": "agentflow.adapters"}
+
+
+def test_load_adapter_plugins_resolves_a_real_entry_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercises real `EntryPoint.load()` import machinery rather than a stub."""
+    entry_point = metadata.EntryPoint(
+        name="real-plugin",
+        value="tests.test_adapter_plugins:create_plugin_adapter",
+        group=discovery.ENTRY_POINT_GROUP,
+    )
+    _set_entry_points(monkeypatch, [entry_point])
+
+    load_adapter_plugins()
+
+    assert isinstance(base.get_adapter("real-plugin"), _PluginAdapter)
+    assert base.get_adapter("real-plugin").name == "real-plugin"
+
+
+def test_load_adapter_plugins_registers_factory_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def create_adapter() -> OrchestratorAdapter:
+        nonlocal calls
+        calls += 1
+        return _PluginAdapter()
+
+    _set_entry_points(
+        monkeypatch,
+        [_EntryPoint("test-plugin", "test_plugin:create_adapter", create_adapter)],
+    )
+
+    load_adapter_plugins()
+    load_adapter_plugins()
+
+    assert calls == 1
+    assert isinstance(base.get_adapter("test-plugin"), _PluginAdapter)
+    assert "test-plugin" in base.list_adapters()
+
+
+def test_load_adapter_plugins_rejects_registered_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = base.get_adapter("echo")
+    _set_entry_points(
+        monkeypatch,
+        [_EntryPoint("echo", "test_plugin:create_adapter", _PluginAdapter)],
+    )
+
+    with pytest.raises(AdapterPluginError, match="already registered"):
+        load_adapter_plugins()
+
+    assert base.get_adapter("echo") is original
+
+
+def test_load_adapter_plugins_wraps_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_entry_points(
+        monkeypatch,
+        [_EntryPoint("broken", "broken:create_adapter", ImportError("missing dependency"))],
+    )
+
+    with pytest.raises(AdapterPluginError, match="broken:create_adapter") as exc_info:
+        load_adapter_plugins()
+
+    assert isinstance(exc_info.value.__cause__, ImportError)
+
+
+def test_load_adapter_plugins_does_not_partially_register(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_entry_points(
+        monkeypatch,
+        [
+            _EntryPoint("first", "first:create_adapter", _PluginAdapter),
+            _EntryPoint("second", "second:create_adapter", lambda: object()),
+        ],
+    )
+
+    with pytest.raises(AdapterPluginError, match="OrchestratorAdapter"):
+        load_adapter_plugins()
+
+    assert "first" not in base.list_adapters()
+
+
+def test_load_adapter_plugins_rolls_back_when_a_factory_self_registers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plugin registering itself on import must not leave the batch half-applied."""
+
+    def self_registering_factory() -> OrchestratorAdapter:
+        base.register_adapter("second", _PluginAdapter())
+        return _PluginAdapter()
+
+    _set_entry_points(
+        monkeypatch,
+        [
+            _EntryPoint("first", "first:create_adapter", _PluginAdapter),
+            _EntryPoint("second", "second:create_adapter", self_registering_factory),
+        ],
+    )
+
+    with pytest.raises(AdapterPluginError, match="already registered"):
+        load_adapter_plugins()
+
+    assert "first" not in base.list_adapters()
+
+
+def test_load_adapter_plugins_rejects_one_instance_under_two_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`get_adapter(name).name == name` is what RunService dispatches on."""
+    shared = _PluginAdapter()
+    _set_entry_points(
+        monkeypatch,
+        [
+            _EntryPoint("one", "shared:create_adapter", lambda: shared),
+            _EntryPoint("two", "shared:create_adapter", lambda: shared),
+        ],
+    )
+
+    with pytest.raises(AdapterPluginError, match="instance already registered"):
+        load_adapter_plugins()
+
+    assert "one" not in base.list_adapters()
+    assert "two" not in base.list_adapters()
+
+
+@pytest.mark.parametrize(
+    ("target", "message"),
+    [
+        (object(), "zero-argument factory"),
+        (lambda: object(), "OrchestratorAdapter"),
+    ],
+)
+def test_load_adapter_plugins_validates_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    target: Any,
+    message: str,
+) -> None:
+    _set_entry_points(
+        monkeypatch,
+        [_EntryPoint("invalid", "invalid:create_adapter", target)],
+    )
+
+    with pytest.raises(AdapterPluginError, match=message):
+        load_adapter_plugins()
+
+
+def test_register_adapter_rejects_a_duplicate_name() -> None:
+    base.register_adapter("dup", _PluginAdapter())
+
+    with pytest.raises(ValueError, match="Adapter already registered"):
+        base.register_adapter("dup", _PluginAdapter())
+
+
+def test_register_adapters_is_atomic() -> None:
+    before = base.list_adapters()
+
+    with pytest.raises(ValueError):
+        base.register_adapters([("fresh", _PluginAdapter()), ("echo", _PluginAdapter())])
+
+    assert base.list_adapters() == before

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -30,6 +30,9 @@ Health probe.
 }
 ```
 
+`adapters` lists whatever is registered at runtime, so it also contains any
+adapter plugin installed through the `agentflow.adapters` entry-point group.
+
 ### `POST /v1/agents` → 201
 
 Request:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,10 +81,38 @@ that created a run must not share a session with the background adapter work.
 
 ## Adding an adapter
 
+Built-in adapters:
+
 1. Subclass `OrchestratorAdapter` in `app/adapters/`.
 2. Implement `async def run(self, ctx: AdapterContext) -> AdapterResult`.
 3. Emit events through `ctx.emit_step_started`, `ctx.emit_message`, etc.
 4. Register it in `app/adapters/__init__.py` via `register_adapter`.
+
+`register_adapter` refuses to rebind a name that is already taken, and refuses
+to register one adapter instance under two names — the runtime resolves a run
+by name and then reads `adapter.name` back to dispatch it, so the two must
+agree.
+
+Third-party adapters can be distributed as separate Python packages. Expose a
+zero-argument factory through the `agentflow.adapters` entry-point group:
+
+```toml
+[project.entry-points."agentflow.adapters"]
+crewai = "agentflow_crewai:create_adapter"
+```
+
+```python
+def create_adapter() -> OrchestratorAdapter:
+    return CrewAIAdapter()
+```
+
+The entry-point name becomes the adapter name. Plugin packages must be
+installed in the Python worker environment before it starts. Duplicate names,
+load failures, and factories that do not return an `OrchestratorAdapter` stop
+startup. Because loading a plugin imports third-party code that may register
+adapters of its own, conflicts are only settled once every factory has run:
+the discovered batch is registered atomically, so a failure leaves the registry
+exactly as it was.
 
 No changes are needed in the DB schema, the `/v1` contract, or the frontend.
 Workers pick up new adapters through the shared Python adapter registry.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -45,7 +45,7 @@
 
 **目标：** 第三方框架与工具可插拔，无需 fork runtime。
 
-- [ ] Adapter 插件注册表（entry points / 动态加载）
+- [x] Adapter 插件注册表（entry points / 动态加载）
 - [ ] 官方 adapter：AutoGen、CrewAI、PydanticAI（按需求选 2 个）
 - [ ] MCP tool adapter
 - [ ] OpenAPI 规范 + Python/TypeScript SDK 自动生成


### PR DESCRIPTION
- Introduced an `agentflow.adapters` entry-point group so third-party adapters ship as separate packages, discovered at API and worker startup.
- Registered discovered plugins as an atomic batch through `register_adapters`, so a failing factory or a name clash leaves the registry untouched instead of half-applied.
- Hardened `register_adapter` to reject duplicate names and a single instance bound to two names, preserving the `get_adapter(name).name == name` invariant that run dispatch relies on.
- Logged the loaded plugin names at startup and made the built-in registration side effect explicit at both entrypoints.
- Documented plugin packaging in architecture.md and noted that the health endpoint reports adapters dynamically.
- Added tests covering real entry-point resolution, the declared group name, atomic rollback on self-registering factories, and instance aliasing.