### PR TITLE
feat: add run comparison and regression suite

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package io.agentflow.api.controller;
 import io.agentflow.api.service.AgentNameConflictException;
 import io.agentflow.api.service.AgentNotFoundException;
 import io.agentflow.api.service.AgentVersionNotFoundException;
+import io.agentflow.api.service.RegressionExecutionException;
+import io.agentflow.api.service.RunComparisonValidationException;
 import io.agentflow.api.service.RunConflictException;
 import io.agentflow.api.service.RunNotFoundException;
 import java.util.Map;
@@ -42,5 +44,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RunConflictException.class)
     public ResponseEntity<Map<String, String>> handleRunConflict(RunConflictException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("detail", ex.getMessage()));
+    }
+
+    @ExceptionHandler(RunComparisonValidationException.class)
+    public ResponseEntity<Map<String, String>> handleRunComparisonValidation(
+            RunComparisonValidationException ex) {
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(Map.of("detail", ex.getMessage()));
+    }
+
+    @ExceptionHandler(RegressionExecutionException.class)
+    public ResponseEntity<Map<String, String>> handleRegressionExecution(
+            RegressionExecutionException ex) {
+        return ResponseEntity.status(ex.status()).body(Map.of("detail", ex.getMessage()));
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/controller/RegressionExecutionsController.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/RegressionExecutionsController.java
@@ -1,0 +1,43 @@
+package io.agentflow.api.controller;
+
+import io.agentflow.api.dto.RegressionExecutionCreateRequest;
+import io.agentflow.api.dto.RegressionExecutionResponse;
+import io.agentflow.api.dto.RegressionExecutionResultsResponse;
+import io.agentflow.api.service.RegressionExecutionService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/regression-executions")
+public class RegressionExecutionsController {
+
+    private final RegressionExecutionService service;
+
+    public RegressionExecutionsController(RegressionExecutionService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public RegressionExecutionResponse create(
+            @Valid @RequestBody RegressionExecutionCreateRequest payload) {
+        return service.create(payload);
+    }
+
+    @GetMapping("/{executionId}")
+    public RegressionExecutionResponse get(@PathVariable String executionId) {
+        return service.get(executionId);
+    }
+
+    @GetMapping("/{executionId}/results")
+    public RegressionExecutionResultsResponse results(@PathVariable String executionId) {
+        return service.results(executionId);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/controller/RunComparisonsController.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/RunComparisonsController.java
@@ -1,0 +1,27 @@
+package io.agentflow.api.controller;
+
+import io.agentflow.api.dto.RunComparisonPreviewRequest;
+import io.agentflow.api.dto.RunComparisonResponse;
+import io.agentflow.api.service.RunComparisonService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/run-comparisons")
+public class RunComparisonsController {
+
+    private final RunComparisonService service;
+
+    public RunComparisonsController(RunComparisonService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/preview")
+    public RunComparisonResponse preview(
+            @Valid @RequestBody RunComparisonPreviewRequest payload) {
+        return service.preview(payload);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/RegressionExecutionCreateRequest.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RegressionExecutionCreateRequest.java
@@ -1,0 +1,9 @@
+package io.agentflow.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record RegressionExecutionCreateRequest(
+        @NotEmpty @Size(max = 100) List<@NotBlank String> baselineRunIds) {}

--- a/backend-java/src/main/java/io/agentflow/api/dto/RegressionExecutionResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RegressionExecutionResponse.java
@@ -1,0 +1,14 @@
+package io.agentflow.api.dto;
+
+import java.util.List;
+
+public record RegressionExecutionResponse(
+        String executionId,
+        int candidateAgentVersion,
+        String status,
+        int totalCases,
+        int completedCases,
+        List<RunPair> cases) {
+
+    public record RunPair(String baselineRunId, String candidateRunId) {}
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/RegressionExecutionResultsResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RegressionExecutionResultsResponse.java
@@ -1,0 +1,20 @@
+package io.agentflow.api.dto;
+
+import java.util.List;
+
+public record RegressionExecutionResultsResponse(
+        String executionId,
+        boolean passed,
+        int totalCases,
+        int passedCases,
+        int failedCases,
+        List<CaseResult> cases) {
+
+    public record CaseResult(
+            String baselineRunId,
+            String candidateRunId,
+            boolean passed,
+            List<Failure> failures) {}
+
+    public record Failure(String code, String message) {}
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/RunComparisonPreviewRequest.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunComparisonPreviewRequest.java
@@ -1,0 +1,5 @@
+package io.agentflow.api.dto;
+
+public record RunComparisonPreviewRequest(
+        String baselineRunId,
+        String candidateRunId) {}

--- a/backend-java/src/main/java/io/agentflow/api/dto/RunComparisonResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunComparisonResponse.java
@@ -1,0 +1,18 @@
+package io.agentflow.api.dto;
+
+public record RunComparisonResponse(
+        RunSide baseline,
+        RunSide candidate,
+        boolean agentVersionChanged,
+        boolean statusChanged,
+        boolean errorChanged,
+        boolean inputChanged,
+        boolean outputChanged) {
+
+    public record RunSide(
+            String runId,
+            String agentId,
+            Integer agentVersion,
+            String status,
+            String error) {}
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionException.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionException.java
@@ -1,0 +1,32 @@
+package io.agentflow.api.service;
+
+import org.springframework.http.HttpStatus;
+
+public class RegressionExecutionException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    private RegressionExecutionException(HttpStatus status, String message, Throwable cause) {
+        super(message, cause);
+        this.status = status;
+    }
+
+    static RegressionExecutionException invalid(String message) {
+        return new RegressionExecutionException(HttpStatus.UNPROCESSABLE_ENTITY, message, null);
+    }
+
+    static RegressionExecutionException notFound(String executionId) {
+        return new RegressionExecutionException(
+                HttpStatus.NOT_FOUND,
+                "Regression execution not found or expired: " + executionId,
+                null);
+    }
+
+    static RegressionExecutionException unavailable(String message, Throwable cause) {
+        return new RegressionExecutionException(HttpStatus.SERVICE_UNAVAILABLE, message, cause);
+    }
+
+    public HttpStatus status() {
+        return status;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionManifest.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionManifest.java
@@ -1,0 +1,11 @@
+package io.agentflow.api.service;
+
+import java.util.List;
+
+record RegressionExecutionManifest(
+        String executionId,
+        int candidateAgentVersion,
+        List<CaseReference> cases) {
+
+    record CaseReference(String baselineRunId, String candidateRunId) {}
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionService.java
@@ -1,0 +1,244 @@
+package io.agentflow.api.service;
+
+import com.github.f4b6a3.ulid.UlidCreator;
+import io.agentflow.api.dto.RegressionExecutionCreateRequest;
+import io.agentflow.api.dto.RegressionExecutionResponse;
+import io.agentflow.api.dto.RegressionExecutionResponse.RunPair;
+import io.agentflow.api.dto.RegressionExecutionResultsResponse;
+import io.agentflow.api.dto.RegressionExecutionResultsResponse.CaseResult;
+import io.agentflow.api.dto.RegressionExecutionResultsResponse.Failure;
+import io.agentflow.api.dto.RunComparisonPreviewRequest;
+import io.agentflow.api.dto.RunComparisonResponse;
+import io.agentflow.api.entity.AgentEntity;
+import io.agentflow.api.entity.AgentVersionEntity;
+import io.agentflow.api.entity.RunEntity;
+import io.agentflow.api.entity.RunStatus;
+import io.agentflow.api.repository.AgentVersionRepository;
+import io.agentflow.api.repository.RunRepository;
+import io.agentflow.api.service.RegressionExecutionManifest.CaseReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RegressionExecutionService {
+
+    private static final int MAX_CASES = 100;
+
+    private final RunRepository runs;
+    private final AgentVersionRepository versions;
+    private final AgentService agents;
+    private final RunService runService;
+    private final RegressionExecutionStore store;
+    private final RunComparisonService comparisons;
+
+    public RegressionExecutionService(
+            RunRepository runs,
+            AgentVersionRepository versions,
+            AgentService agents,
+            RunService runService,
+            RegressionExecutionStore store,
+            RunComparisonService comparisons) {
+        this.runs = runs;
+        this.versions = versions;
+        this.agents = agents;
+        this.runService = runService;
+        this.store = store;
+        this.comparisons = comparisons;
+    }
+
+    public RegressionExecutionResponse create(RegressionExecutionCreateRequest request) {
+        List<String> baselineIds = normalizeIds(request);
+        Map<String, RunEntity> loaded = byId(runs.findAllById(baselineIds));
+        List<RunEntity> baselines = baselineIds.stream()
+                .map(id -> {
+                    RunEntity run = loaded.get(id);
+                    if (run == null) {
+                        throw new RunNotFoundException(id);
+                    }
+                    return run;
+                })
+                .toList();
+        validateBaselines(baselines);
+
+        String agentId = baselines.getFirst().getAgentId();
+        AgentEntity agent = agents.getEntity(agentId);
+        int candidateVersion = agent.getVersion();
+        AgentVersionEntity snapshot = versions.findByAgentIdAndVersion(agentId, candidateVersion)
+                .orElseThrow(() -> new AgentVersionNotFoundException(candidateVersion));
+        List<Map<String, Object>> inputs = baselines.stream()
+                .<Map<String, Object>>map(run -> new HashMap<>(run.getInput()))
+                .toList();
+        List<RunEntity> candidates = runService.createPinnedCopies(
+                agentId, snapshot.getAdapter(), candidateVersion, inputs);
+        if (candidates.size() != baselines.size()) {
+            throw new IllegalStateException("Candidate Run count does not match baseline count");
+        }
+
+        List<CaseReference> cases = new ArrayList<>(baselines.size());
+        for (int index = 0; index < baselines.size(); index++) {
+            cases.add(new CaseReference(
+                    baselines.get(index).getId(), candidates.get(index).getId()));
+        }
+        RegressionExecutionManifest manifest = new RegressionExecutionManifest(
+                "reg_" + UlidCreator.getUlid(),
+                candidateVersion,
+                List.copyOf(cases));
+        store.save(manifest);
+        runService.enqueueCandidates(candidates);
+        return response(manifest, byId(candidates));
+    }
+
+    public RegressionExecutionResponse get(String executionId) {
+        RegressionExecutionManifest manifest = manifest(executionId);
+        return response(manifest, candidateRuns(manifest));
+    }
+
+    public RegressionExecutionResultsResponse results(String executionId) {
+        RegressionExecutionManifest manifest = manifest(executionId);
+        Map<String, RunEntity> candidates = candidateRuns(manifest);
+        if (candidates.values().stream().anyMatch(run -> !isTerminal(run.getStatus()))) {
+            throw new RunConflictException(
+                    "Regression execution is not complete: " + manifest.executionId());
+        }
+
+        List<CaseResult> results = new ArrayList<>(manifest.cases().size());
+        int passed = 0;
+        for (CaseReference item : manifest.cases()) {
+            RunComparisonResponse comparison = comparisons.preview(
+                    new RunComparisonPreviewRequest(
+                            item.baselineRunId(), item.candidateRunId()));
+            List<Failure> failures = evaluate(comparison);
+            boolean casePassed = failures.isEmpty();
+            if (casePassed) {
+                passed++;
+            }
+            results.add(new CaseResult(
+                    item.baselineRunId(),
+                    item.candidateRunId(),
+                    casePassed,
+                    failures));
+        }
+        int total = results.size();
+        return new RegressionExecutionResultsResponse(
+                manifest.executionId(),
+                passed == total,
+                total,
+                passed,
+                total - passed,
+                List.copyOf(results));
+    }
+
+    private RegressionExecutionManifest manifest(String executionId) {
+        String normalized = executionId == null ? "" : executionId.strip();
+        if (normalized.isEmpty()) {
+            throw RegressionExecutionException.notFound(normalized);
+        }
+        return store.find(normalized)
+                .orElseThrow(() -> RegressionExecutionException.notFound(normalized));
+    }
+
+    private Map<String, RunEntity> candidateRuns(RegressionExecutionManifest manifest) {
+        List<String> ids = manifest.cases().stream()
+                .map(CaseReference::candidateRunId)
+                .toList();
+        Map<String, RunEntity> result = byId(runs.findAllById(ids));
+        for (String id : ids) {
+            if (!result.containsKey(id)) {
+                throw new RunNotFoundException(id);
+            }
+        }
+        return result;
+    }
+
+    private static RegressionExecutionResponse response(
+            RegressionExecutionManifest manifest, Map<String, RunEntity> candidates) {
+        List<RunPair> cases = manifest.cases().stream()
+                .map(item -> new RunPair(item.baselineRunId(), item.candidateRunId()))
+                .toList();
+        int completed = (int) candidates.values().stream()
+                .filter(run -> isTerminal(run.getStatus()))
+                .count();
+        int total = candidates.size();
+        boolean allPending = candidates.values().stream()
+                .allMatch(run -> run.getStatus() == RunStatus.PENDING);
+        String status = completed == total ? "completed" : allPending ? "pending" : "running";
+        return new RegressionExecutionResponse(
+                manifest.executionId(),
+                manifest.candidateAgentVersion(),
+                status,
+                total,
+                completed,
+                cases);
+    }
+
+    private static List<Failure> evaluate(RunComparisonResponse comparison) {
+        List<Failure> failures = new ArrayList<>();
+        if (comparison.statusChanged()) {
+            failures.add(new Failure("status_changed", "Candidate status differs from baseline"));
+        }
+        if (comparison.errorChanged()) {
+            failures.add(new Failure("error_changed", "Candidate error differs from baseline"));
+        }
+        return List.copyOf(failures);
+    }
+
+    private static List<String> normalizeIds(RegressionExecutionCreateRequest request) {
+        if (request == null
+                || request.baselineRunIds() == null
+                || request.baselineRunIds().isEmpty()) {
+            throw RegressionExecutionException.invalid(
+                    "baseline_run_ids must contain at least one Run ID");
+        }
+        if (request.baselineRunIds().size() > MAX_CASES) {
+            throw RegressionExecutionException.invalid(
+                    "baseline_run_ids must contain at most 100 Run IDs");
+        }
+        LinkedHashSet<String> ids = new LinkedHashSet<>();
+        for (String raw : request.baselineRunIds()) {
+            String id = raw == null ? "" : raw.strip();
+            if (id.isEmpty()) {
+                throw RegressionExecutionException.invalid(
+                        "baseline_run_ids must not contain blank values");
+            }
+            if (!ids.add(id)) {
+                throw RegressionExecutionException.invalid(
+                        "baseline_run_ids must not contain duplicates");
+            }
+        }
+        return List.copyOf(ids);
+    }
+
+    private static void validateBaselines(List<RunEntity> baselines) {
+        String agentId = baselines.getFirst().getAgentId();
+        if (baselines.stream().anyMatch(run -> !Objects.equals(agentId, run.getAgentId()))) {
+            throw RegressionExecutionException.invalid(
+                    "Baseline runs must belong to the same agent");
+        }
+        List<String> nonTerminal = baselines.stream()
+                .filter(run -> !isTerminal(run.getStatus()))
+                .map(run -> run.getId() + " (" + run.getStatus().wire() + ")")
+                .toList();
+        if (!nonTerminal.isEmpty()) {
+            throw new RunConflictException(
+                    "All baseline runs must be terminal; non-terminal runs: "
+                            + String.join(", ", nonTerminal));
+        }
+    }
+
+    private static Map<String, RunEntity> byId(Iterable<RunEntity> values) {
+        Map<String, RunEntity> result = new HashMap<>();
+        values.forEach(run -> result.put(run.getId(), run));
+        return result;
+    }
+
+    private static boolean isTerminal(RunStatus status) {
+        return status == RunStatus.SUCCEEDED
+                || status == RunStatus.FAILED
+                || status == RunStatus.CANCELLED;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionService.java
@@ -88,7 +88,12 @@ public class RegressionExecutionService {
                 "reg_" + UlidCreator.getUlid(),
                 candidateVersion,
                 List.copyOf(cases));
-        store.save(manifest);
+        try {
+            store.save(manifest);
+        } catch (RuntimeException ex) {
+            runs.deleteAll(candidates);
+            throw ex;
+        }
         runService.enqueueCandidates(candidates);
         return response(manifest, byId(candidates));
     }

--- a/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionStore.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionStore.java
@@ -1,0 +1,50 @@
+package io.agentflow.api.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Optional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RegressionExecutionStore {
+
+    private static final String KEY_PREFIX = "agentflow:regression:execution:";
+    private static final Duration TTL = Duration.ofDays(30);
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper mapper;
+
+    public RegressionExecutionStore(StringRedisTemplate redis, ObjectMapper mapper) {
+        this.redis = redis;
+        this.mapper = mapper;
+    }
+
+    public void save(RegressionExecutionManifest manifest) {
+        try {
+            redis.opsForValue().set(
+                    key(manifest.executionId()), mapper.writeValueAsString(manifest), TTL);
+        } catch (JsonProcessingException | RuntimeException ex) {
+            throw RegressionExecutionException.unavailable(
+                    "Failed to store temporary regression execution manifest", ex);
+        }
+    }
+
+    public Optional<RegressionExecutionManifest> find(String executionId) {
+        try {
+            String json = redis.opsForValue().get(key(executionId));
+            if (json == null) {
+                return Optional.empty();
+            }
+            return Optional.of(mapper.readValue(json, RegressionExecutionManifest.class));
+        } catch (JsonProcessingException | RuntimeException ex) {
+            throw RegressionExecutionException.unavailable(
+                    "Failed to read temporary regression execution manifest", ex);
+        }
+    }
+
+    private String key(String executionId) {
+        return KEY_PREFIX + executionId;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RunComparisonService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunComparisonService.java
@@ -1,0 +1,118 @@
+package io.agentflow.api.service;
+
+import io.agentflow.api.dto.RunComparisonPreviewRequest;
+import io.agentflow.api.dto.RunComparisonResponse;
+import io.agentflow.api.dto.RunComparisonResponse.RunSide;
+import io.agentflow.api.entity.RunEntity;
+import io.agentflow.api.entity.RunStatus;
+import io.agentflow.api.repository.RunRepository;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RunComparisonService {
+
+    private final RunRepository runs;
+
+    public RunComparisonService(RunRepository runs) {
+        this.runs = runs;
+    }
+
+    @Transactional(readOnly = true)
+    public RunComparisonResponse preview(RunComparisonPreviewRequest request) {
+        String baselineId = normalizedId(
+                request == null ? null : request.baselineRunId(), "baseline_run_id");
+        String candidateId = normalizedId(
+                request == null ? null : request.candidateRunId(), "candidate_run_id");
+        if (baselineId.equals(candidateId)) {
+            throw new RunComparisonValidationException(
+                    "Baseline and candidate run IDs must differ.");
+        }
+
+        RunEntity baseline = runs.findById(baselineId)
+                .orElseThrow(() -> new RunNotFoundException(baselineId));
+        RunEntity candidate = runs.findById(candidateId)
+                .orElseThrow(() -> new RunNotFoundException(candidateId));
+        if (!Objects.equals(baseline.getAgentId(), candidate.getAgentId())) {
+            throw new RunComparisonValidationException(
+                    "Runs must belong to the same agent.");
+        }
+        requireTerminal(baseline, candidate);
+
+        Integer baselineVersion = agentVersion(baseline.getMetadata());
+        Integer candidateVersion = agentVersion(candidate.getMetadata());
+        String baselineStatus = baseline.getStatus().wire();
+        String candidateStatus = candidate.getStatus().wire();
+        return new RunComparisonResponse(
+                side(baseline, baselineVersion),
+                side(candidate, candidateVersion),
+                !Objects.equals(baselineVersion, candidateVersion),
+                !Objects.equals(baselineStatus, candidateStatus),
+                !Objects.equals(baseline.getError(), candidate.getError()),
+                !Objects.equals(baseline.getInput(), candidate.getInput()),
+                !Objects.equals(baseline.getOutput(), candidate.getOutput()));
+    }
+
+    private static RunSide side(RunEntity run, Integer version) {
+        return new RunSide(
+                run.getId(),
+                run.getAgentId(),
+                version,
+                run.getStatus().wire(),
+                run.getError());
+    }
+
+    private static Integer agentVersion(Map<String, Object> metadata) {
+        if (metadata == null || !(metadata.get("_agentflow") instanceof Map<?, ?> internal)) {
+            return null;
+        }
+        Object raw = internal.get("agent_version");
+        if (!(raw instanceof Byte
+                || raw instanceof Short
+                || raw instanceof Integer
+                || raw instanceof Long
+                || raw instanceof BigInteger)) {
+            return null;
+        }
+        try {
+            int version = new BigInteger(raw.toString()).intValueExact();
+            return version > 0 ? version : null;
+        } catch (ArithmeticException | NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static String normalizedId(String value, String field) {
+        String normalized = value == null ? "" : value.strip();
+        if (normalized.isEmpty()) {
+            throw new RunComparisonValidationException(field + " must not be blank.");
+        }
+        return normalized;
+    }
+
+    private static void requireTerminal(RunEntity baseline, RunEntity candidate) {
+        List<String> nonTerminal = new ArrayList<>();
+        if (!isTerminal(baseline.getStatus())) {
+            nonTerminal.add(baseline.getId() + " (" + baseline.getStatus().wire() + ")");
+        }
+        if (!isTerminal(candidate.getStatus())) {
+            nonTerminal.add(candidate.getId() + " (" + candidate.getStatus().wire() + ")");
+        }
+        if (!nonTerminal.isEmpty()) {
+            throw new RunConflictException(
+                    "Both runs must be terminal; non-terminal runs: "
+                            + String.join(", ", nonTerminal));
+        }
+    }
+
+    private static boolean isTerminal(RunStatus status) {
+        return status == RunStatus.SUCCEEDED
+                || status == RunStatus.FAILED
+                || status == RunStatus.CANCELLED;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RunComparisonValidationException.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunComparisonValidationException.java
@@ -1,0 +1,8 @@
+package io.agentflow.api.service;
+
+public class RunComparisonValidationException extends RuntimeException {
+
+    public RunComparisonValidationException(String message) {
+        super(message);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RunService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunService.java
@@ -21,6 +21,7 @@ import io.agentflow.api.repository.MessageRepository;
 import io.agentflow.api.repository.RunRepository;
 import io.agentflow.api.repository.StepRepository;
 import io.agentflow.api.repository.ToolCallRepository;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,9 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  */
 @Service
 public class RunService {
+
+    private static final String INTERNAL_METADATA_KEY = "_agentflow";
+    private static final String AGENT_VERSION_METADATA_KEY = "agent_version";
 
     private final RunRepository runs;
     private final StepRepository steps;
@@ -80,11 +84,43 @@ public class RunService {
         run.setAdapter(adapter);
         run.setStatus(RunStatus.PENDING);
         run.setInput(new HashMap<>(req.getInput()));
-        run.setMetadata(new HashMap<>(req.getMetadata()));
+        Map<String, Object> metadata = new HashMap<>(req.getMetadata());
+        metadata.put(
+                INTERNAL_METADATA_KEY,
+                Map.of(AGENT_VERSION_METADATA_KEY, agent.getVersion()));
+        run.setMetadata(metadata);
         RunEntity saved = runs.save(run);
         enqueueJobAfterCommit(saved.getId(), agent.getId(), adapter);
 
         return toResponse(saved);
+    }
+
+    /** Persist server-pinned candidate Runs without dispatching them yet. */
+    @Transactional
+    public List<RunEntity> createPinnedCopies(
+            String agentId,
+            String adapter,
+            int agentVersion,
+            List<Map<String, Object>> inputs) {
+        List<RunEntity> candidates = new ArrayList<>(inputs.size());
+        for (Map<String, Object> input : inputs) {
+            RunEntity run = new RunEntity();
+            run.setAgentId(agentId);
+            run.setAdapter(adapter);
+            run.setStatus(RunStatus.PENDING);
+            run.setInput(new HashMap<>(input));
+            run.setMetadata(Map.of(
+                    INTERNAL_METADATA_KEY,
+                    Map.of(AGENT_VERSION_METADATA_KEY, agentVersion)));
+            candidates.add(run);
+        }
+        return List.copyOf(runs.saveAll(candidates));
+    }
+
+    /** Dispatch already-committed candidate Runs after their Redis manifest exists. */
+    public void enqueueCandidates(List<RunEntity> candidates) {
+        candidates.forEach(run ->
+                jobProducer.enqueue(run.getId(), run.getAgentId(), run.getAdapter()));
     }
 
     @Transactional(readOnly = true)

--- a/backend-java/src/test/java/io/agentflow/api/service/RegressionExecutionServiceTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/service/RegressionExecutionServiceTest.java
@@ -1,0 +1,83 @@
+package io.agentflow.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentflow.api.dto.RegressionExecutionCreateRequest;
+import io.agentflow.api.dto.RunComparisonResponse;
+import io.agentflow.api.entity.AgentEntity;
+import io.agentflow.api.entity.AgentVersionEntity;
+import io.agentflow.api.entity.RunEntity;
+import io.agentflow.api.entity.RunStatus;
+import io.agentflow.api.repository.AgentVersionRepository;
+import io.agentflow.api.repository.RunRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RegressionExecutionServiceTest {
+
+    @Test
+    void createsPinnedCandidatesAndIgnoresOutputDifferences() {
+        RunRepository runs = mock(RunRepository.class);
+        AgentVersionRepository versions = mock(AgentVersionRepository.class);
+        AgentService agents = mock(AgentService.class);
+        RunService runService = mock(RunService.class);
+        RegressionExecutionStore store = mock(RegressionExecutionStore.class);
+        RunComparisonService comparisons = mock(RunComparisonService.class);
+        RegressionExecutionService service = new RegressionExecutionService(
+                runs, versions, agents, runService, store, comparisons);
+        RunEntity baseline1 = run("base-1", RunStatus.SUCCEEDED, Map.of("prompt", "one"));
+        RunEntity candidate1 = run("candidate-1", RunStatus.PENDING, Map.of("prompt", "one"));
+        AgentEntity agent = new AgentEntity();
+        agent.setId("agent-1");
+        agent.setVersion(4);
+        AgentVersionEntity snapshot = new AgentVersionEntity();
+        snapshot.setAdapter("echo");
+        when(runs.findAllById(List.of("base-1"))).thenReturn(List.of(baseline1));
+        when(runs.findAllById(List.of("candidate-1"))).thenReturn(List.of(candidate1));
+        when(agents.getEntity("agent-1")).thenReturn(agent);
+        when(versions.findByAgentIdAndVersion("agent-1", 4)).thenReturn(Optional.of(snapshot));
+        when(runService.createPinnedCopies(any(), any(), any(Integer.class), any()))
+                .thenReturn(List.of(candidate1));
+        var created = service.create(new RegressionExecutionCreateRequest(List.of("base-1")));
+
+        ArgumentCaptor<RegressionExecutionManifest> manifest =
+                ArgumentCaptor.forClass(RegressionExecutionManifest.class);
+        verify(store).save(manifest.capture());
+        verify(runService).createPinnedCopies(
+                "agent-1",
+                "echo",
+                4,
+                List.of(Map.of("prompt", "one")));
+        verify(runService).enqueueCandidates(List.of(candidate1));
+        assertThat(created.status()).isEqualTo("pending");
+        assertThat(created.candidateAgentVersion()).isEqualTo(4);
+        when(store.find(created.executionId())).thenReturn(Optional.of(manifest.getValue()));
+
+        candidate1.setStatus(RunStatus.SUCCEEDED);
+        RunComparisonResponse comparison = mock(RunComparisonResponse.class);
+        when(comparison.outputChanged()).thenReturn(true);
+        when(comparisons.preview(any())).thenReturn(comparison);
+        var results = service.results(created.executionId());
+
+        assertThat(results.passedCases()).isEqualTo(1);
+        assertThat(results.failedCases()).isZero();
+    }
+
+    private static RunEntity run(String id, RunStatus status, Map<String, Object> input) {
+        RunEntity run = new RunEntity();
+        run.setId(id);
+        run.setAgentId("agent-1");
+        run.setAdapter("echo");
+        run.setStatus(status);
+        run.setInput(input);
+        return run;
+    }
+
+}

--- a/backend-java/src/test/java/io/agentflow/api/service/RegressionExecutionServiceTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/service/RegressionExecutionServiceTest.java
@@ -1,8 +1,11 @@
 package io.agentflow.api.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +71,45 @@ class RegressionExecutionServiceTest {
 
         assertThat(results.passedCases()).isEqualTo(1);
         assertThat(results.failedCases()).isZero();
+    }
+
+    @Test
+    void deletesCandidatesWhenManifestSaveFails() {
+        RunRepository runs = mock(RunRepository.class);
+        AgentVersionRepository versions = mock(AgentVersionRepository.class);
+        AgentService agents = mock(AgentService.class);
+        RunService runService = mock(RunService.class);
+        RegressionExecutionStore store = mock(RegressionExecutionStore.class);
+        RegressionExecutionService service = new RegressionExecutionService(
+                runs,
+                versions,
+                agents,
+                runService,
+                store,
+                mock(RunComparisonService.class));
+        RunEntity baseline = run("base-1", RunStatus.SUCCEEDED, Map.of("prompt", "one"));
+        RunEntity candidate = run("candidate-1", RunStatus.PENDING, Map.of("prompt", "one"));
+        AgentEntity agent = new AgentEntity();
+        agent.setId("agent-1");
+        agent.setVersion(4);
+        AgentVersionEntity snapshot = new AgentVersionEntity();
+        snapshot.setAdapter("echo");
+        RegressionExecutionException failure = RegressionExecutionException.unavailable(
+                "Failed to store temporary regression execution manifest",
+                new RuntimeException("Redis unavailable"));
+        when(runs.findAllById(List.of("base-1"))).thenReturn(List.of(baseline));
+        when(agents.getEntity("agent-1")).thenReturn(agent);
+        when(versions.findByAgentIdAndVersion("agent-1", 4)).thenReturn(Optional.of(snapshot));
+        when(runService.createPinnedCopies(any(), any(), any(Integer.class), any()))
+                .thenReturn(List.of(candidate));
+        doThrow(failure).when(store).save(any());
+
+        assertThatThrownBy(() ->
+                        service.create(new RegressionExecutionCreateRequest(List.of("base-1"))))
+                .isSameAs(failure);
+
+        verify(runs).deleteAll(List.of(candidate));
+        verify(runService, never()).enqueueCandidates(any());
     }
 
     private static RunEntity run(String id, RunStatus status, Map<String, Object> input) {

--- a/backend-java/src/test/java/io/agentflow/api/service/RunComparisonServiceTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/service/RunComparisonServiceTest.java
@@ -1,0 +1,47 @@
+package io.agentflow.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentflow.api.dto.RunComparisonPreviewRequest;
+import io.agentflow.api.entity.RunEntity;
+import io.agentflow.api.entity.RunStatus;
+import io.agentflow.api.repository.RunRepository;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RunComparisonServiceTest {
+
+    @Test
+    void comparesSimpleRunSummary() {
+        RunRepository runs = mock(RunRepository.class);
+        RunEntity baseline = run("baseline", 1, Map.of("answer", "old"));
+        RunEntity candidate = run("candidate", 2, Map.of("answer", "new"));
+        when(runs.findById("baseline")).thenReturn(Optional.of(baseline));
+        when(runs.findById("candidate")).thenReturn(Optional.of(candidate));
+
+        var result = new RunComparisonService(runs)
+                .preview(new RunComparisonPreviewRequest("baseline", "candidate"));
+
+        assertThat(result.baseline().agentVersion()).isEqualTo(1);
+        assertThat(result.candidate().agentVersion()).isEqualTo(2);
+        assertThat(result.agentVersionChanged()).isTrue();
+        assertThat(result.inputChanged()).isFalse();
+        assertThat(result.outputChanged()).isTrue();
+        assertThat(result.statusChanged()).isFalse();
+        assertThat(result.errorChanged()).isFalse();
+    }
+
+    private static RunEntity run(String id, int version, Map<String, Object> output) {
+        RunEntity run = new RunEntity();
+        run.setId(id);
+        run.setAgentId("agent-1");
+        run.setStatus(RunStatus.SUCCEEDED);
+        run.setInput(Map.of("prompt", "same"));
+        run.setOutput(output);
+        run.setMetadata(Map.of("_agentflow", Map.of("agent_version", version)));
+        return run;
+    }
+}

--- a/backend-java/src/test/java/io/agentflow/api/service/RunServiceTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/service/RunServiceTest.java
@@ -1,0 +1,83 @@
+package io.agentflow.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentflow.api.dto.RunCreateRequest;
+import io.agentflow.api.entity.AgentEntity;
+import io.agentflow.api.entity.RunEntity;
+import io.agentflow.api.jobs.CancelSignal;
+import io.agentflow.api.jobs.JobProducer;
+import io.agentflow.api.repository.CheckpointRepository;
+import io.agentflow.api.repository.MessageRepository;
+import io.agentflow.api.repository.RunRepository;
+import io.agentflow.api.repository.StepRepository;
+import io.agentflow.api.repository.ToolCallRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RunServiceTest {
+
+    @Test
+    void createPinsVersionAndReplacesClientInternalMetadata() {
+        RunRepository runs = mock(RunRepository.class);
+        AgentService agents = mock(AgentService.class);
+        AgentEntity agent = new AgentEntity();
+        agent.setId("agent-1");
+        agent.setAdapter("echo");
+        agent.setVersion(3);
+        when(agents.getEntity("agent-1")).thenReturn(agent);
+        when(runs.save(any())).thenAnswer(call -> {
+            RunEntity run = call.getArgument(0);
+            run.setId("run-1");
+            return run;
+        });
+        RunService service = service(runs, agents);
+        RunCreateRequest request = new RunCreateRequest();
+        request.setAgentId("agent-1");
+        request.setMetadata(Map.of(
+                "trace_id", "kept",
+                "_agentflow", Map.of("agent_version", 999, "injected", true)));
+
+        service.create(request);
+
+        verify(runs).save(argThat(run -> run.getMetadata().equals(Map.of(
+                "trace_id", "kept",
+                "_agentflow", Map.of("agent_version", 3)))));
+    }
+
+    @Test
+    void createPinnedCopiesUsesSpecifiedSnapshotVersion() {
+        RunRepository runs = mock(RunRepository.class);
+        when(runs.saveAll(any())).thenAnswer(call -> {
+            List<RunEntity> saved = call.getArgument(0);
+            saved.getFirst().setId("candidate-1");
+            return saved;
+        });
+        RunService service = service(runs, mock(AgentService.class));
+
+        List<RunEntity> candidates = service.createPinnedCopies(
+                "agent-1", "echo", 4, List.of(Map.of("prompt", "hello")));
+
+        assertThat(candidates.getFirst().getInput()).isEqualTo(Map.of("prompt", "hello"));
+        assertThat(candidates.getFirst().getMetadata())
+                .isEqualTo(Map.of("_agentflow", Map.of("agent_version", 4)));
+    }
+
+    private static RunService service(RunRepository runs, AgentService agents) {
+        return new RunService(
+                runs,
+                mock(StepRepository.class),
+                mock(MessageRepository.class),
+                mock(ToolCallRepository.class),
+                mock(CheckpointRepository.class),
+                agents,
+                mock(JobProducer.class),
+                mock(CancelSignal.class));
+    }
+}

--- a/backend/app/services/agent_versions.py
+++ b/backend/app/services/agent_versions.py
@@ -9,6 +9,35 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent import Agent, AgentVersion
 
+INTERNAL_METADATA_KEY = "_agentflow"
+AGENT_VERSION_METADATA_KEY = "agent_version"
+
+
+class InvalidAgentVersionMetadata(ValueError):
+    """A run contains an agent-version pin that cannot identify a snapshot."""
+
+
+def agent_version_from_metadata(metadata: dict[str, Any] | None) -> int | None:
+    """Read a run's version pin, returning ``None`` only for legacy runs."""
+    if not metadata or INTERNAL_METADATA_KEY not in metadata:
+        return None
+
+    internal = metadata[INTERNAL_METADATA_KEY]
+    if not isinstance(internal, dict):
+        raise InvalidAgentVersionMetadata(
+            f"{INTERNAL_METADATA_KEY} must be an object"
+        )
+    if AGENT_VERSION_METADATA_KEY not in internal:
+        return None
+
+    version = internal[AGENT_VERSION_METADATA_KEY]
+    if isinstance(version, bool) or not isinstance(version, int) or version < 1:
+        raise InvalidAgentVersionMetadata(
+            f"{INTERNAL_METADATA_KEY}.{AGENT_VERSION_METADATA_KEY} "
+            "must be a positive integer"
+        )
+    return version
+
 
 def snapshot_agent(
     agent: Agent,

--- a/backend/app/worker/executor.py
+++ b/backend/app/worker/executor.py
@@ -37,6 +37,11 @@ from app.runtime.resume_context import (
     without_resume_metadata,
 )
 from app.schemas.run import EventType
+from app.services.agent_versions import (
+    InvalidAgentVersionMetadata,
+    agent_version_from_metadata,
+    get_agent_version,
+)
 from app.worker.cancel import CancelRegistry, InMemoryCancelRegistry
 
 logger = get_logger("worker.executor")
@@ -79,6 +84,32 @@ class RunExecutor:
                 await self._safe_clear_cancel(run_id)
                 return
 
+            try:
+                agent_version = agent_version_from_metadata(run.metadata_)
+            except InvalidAgentVersionMetadata as exc:
+                await service._finalize(
+                    run_id,
+                    RunStatus.FAILED,
+                    error=f"invalid agent version metadata: {exc}",
+                )
+                return
+
+            if agent_version is None:
+                agent_config = dict(agent.config or {})
+            else:
+                snapshot = await get_agent_version(session, run.agent_id, agent_version)
+                if snapshot is None:
+                    await service._finalize(
+                        run_id,
+                        RunStatus.FAILED,
+                        error=(
+                            "agent version snapshot missing: "
+                            f"agent_id={run.agent_id}, version={agent_version}"
+                        ),
+                    )
+                    return
+                agent_config = dict(snapshot.config or {})
+
             resume_ctx = parse_resume_context(run.metadata_)
             if resume_ctx is not None:
                 run.metadata_ = without_resume_metadata(dict(run.metadata_ or {}))
@@ -102,7 +133,7 @@ class RunExecutor:
             ctx = AdapterContext(
                 run_id=run.id,
                 agent_id=agent.id,
-                agent_config=agent.config or {},
+                agent_config=agent_config,
                 input=run.input,
                 metadata=run.metadata_,
                 resume=resume_ctx,

--- a/backend/tests/test_worker_queue.py
+++ b/backend/tests/test_worker_queue.py
@@ -26,6 +26,7 @@ from app.db.session import SessionLocal, engine
 from app.events import get_event_bus
 from app.models import Agent, Run, RunStatus, Step
 from app.schemas.run import RunCreate
+from app.services.agent_versions import snapshot_agent
 from app.services.run_service import RunService
 from app.worker.cancel import InMemoryCancelRegistry
 from app.worker.executor import RunExecutor
@@ -150,6 +151,41 @@ class _SlowAdapter(OrchestratorAdapter):
             await asyncio.sleep(0.05)
             await ctx.emit_step_completed(index=i, node=f"step-{i}")
         return AdapterResult(status=RunStatus.SUCCEEDED, output={})
+
+
+class _ConfigCaptureAdapter(OrchestratorAdapter):
+    async def run(self, ctx: AdapterContext) -> AdapterResult:
+        return AdapterResult(
+            status=RunStatus.SUCCEEDED,
+            output={"agent_config": ctx.agent_config},
+        )
+
+
+@pytest.mark.asyncio
+async def test_executor_uses_pinned_agent_snapshot():
+    adapter_name = "version-config-test"
+    register_adapter(adapter_name, _ConfigCaptureAdapter())
+    async with SessionLocal() as session:
+        agent = Agent(name="version-agent", adapter=adapter_name, config={"revision": "v1"})
+        session.add(agent)
+        await session.flush()
+        version = snapshot_agent(agent, note="initial")
+        agent.config = {"revision": "v2"}
+        agent.version = 2
+        run = Run(
+            agent_id=agent.id,
+            adapter=adapter_name,
+            metadata_={"_agentflow": {"agent_version": 1}},
+        )
+        session.add_all([version, run])
+        await session.commit()
+
+    executor = RunExecutor(bus=get_event_bus(), cancel_registry=InMemoryCancelRegistry())
+    await executor.execute(run.id, adapter_name)
+
+    async with SessionLocal() as session:
+        loaded = await session.get(Run, run.id)
+        assert loaded.output == {"agent_config": {"revision": "v1"}}
 
 
 @pytest.mark.asyncio

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -109,7 +109,16 @@ Request:
 ```
 
 `metadata` and `adapter` are optional. When `adapter` is omitted the agent's
-default adapter is used.
+default adapter is used. The server replaces the reserved `_agentflow`
+metadata namespace and records the agent's current version as
+`_agentflow.agent_version`; client-supplied values in that namespace are never
+trusted.
+
+The Python worker resolves a pinned run through
+`agent_id + _agentflow.agent_version` and executes the corresponding immutable
+`AgentVersion.config` snapshot. A pinned run fails explicitly if that snapshot
+is missing. Only legacy runs without a version pin fall back to the agent's
+current config.
 
 Response: a full `Run` record. The run is created with status `pending` and
 a background job is dispatched to a worker; the response returns before the
@@ -166,6 +175,88 @@ Request (optional body):
 
 Response: a full `Run` record with status `pending`. Returns **404** if missing,
 **409** if status is not `waiting_human`.
+
+### `POST /v1/run-comparisons/preview` → 200
+
+Returns a read-only summary comparison of two terminal runs. It does not
+persist a comparison or execute either run again.
+
+Request:
+
+```json
+{
+  "baseline_run_id": "01HZ...A",
+  "candidate_run_id": "01HZ...B"
+}
+```
+
+Both runs must exist, have different IDs, belong to the same Agent, and be in
+`succeeded`, `failed`, or `cancelled`. The response contains each Run's ID,
+Agent ID, pinned AgentVersion, status and error, plus boolean flags indicating
+whether the version, status, error, input or output changed. A `null` version
+identifies a historical Run without a version pin. Output changes are
+diagnostic only and do not fail regression cases.
+
+The endpoint intentionally does not compute field-level JSON changes, align
+Steps, or aggregate token, cost and latency metrics. Those records remain
+available from the normal Run read endpoint.
+
+Returns **404** when either run is missing, **409** while either run is not
+terminal, and **422** for identical run IDs or runs owned by different agents.
+
+### `POST /v1/regression-executions` → 202
+
+Starts an ephemeral regression execution from 1–100 terminal baseline Runs.
+All baselines must belong to the same Agent. The Java API resolves that
+Agent's current immutable version snapshot once, copies each baseline input
+into a new candidate Run pinned to that one version, and dispatches the
+candidates through the normal Python Worker queue.
+
+Request:
+
+```json
+{
+  "baseline_run_ids": ["01HZ...A", "01HZ...B"]
+}
+```
+
+Candidate version metadata is server-owned and cannot be supplied by the
+client. Duplicate IDs are rejected and a request is limited to 100 Runs to
+avoid accidentally flooding the worker queue.
+
+The response contains one temporary `execution_id`, the fixed candidate Agent
+version, total/completed counts, and baseline/candidate Run ID pairs. The
+execution manifest is JSON stored at
+`agentflow:regression:execution:{execution_id}` in Redis and expires after 30
+days. Runs, Steps, outputs, metrics, and AgentVersion snapshots remain in
+Postgres. No regression database table is created.
+
+Returns **404** if a baseline Run or current AgentVersion snapshot is missing,
+**409** if a baseline is non-terminal, **422** for duplicate IDs or mixed
+Agents, and **503** if the temporary Redis manifest cannot be stored.
+
+### `GET /v1/regression-executions/{execution_id}` → 200
+
+Loads the Run pairs from Redis, reads candidate Run states from Postgres, and
+returns current progress. Redis is not treated as the source of truth for Run
+status. Overall status is `pending`, `running`, or `completed`, with only total
+and completed counts returned. Failed and cancelled candidates are terminal
+and therefore count as completed cases.
+
+Returns **404** when the manifest is missing or has expired.
+
+### `GET /v1/regression-executions/{execution_id}/results` → 200
+
+Available after every candidate Run is terminal. Each pair is evaluated with
+the existing Run-comparison service. A case passes when status and error are
+unchanged; output differences remain diagnostic and do not fail LLM-backed
+cases. The response includes per-case pass/fail reasons and total passed and
+failed counts; callers can use the standalone comparison endpoint for the
+simple version, status, error, input and output change summary.
+
+Returns **409** while any candidate Run is non-terminal and **404** when the
+manifest is missing or expired. Results are computed from Postgres on demand;
+they are not persisted separately.
 
 ### `GET /v1/events/{run_id}` → 200 `text/event-stream`
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -91,6 +91,6 @@
 | 事件重放 | `backend/app/events/bus.py`、`backend/app/api/v1/events.py` |
 | 修控制台 | `frontend/app/runs/`、`frontend/components/` |
 | 新 adapter | `backend/app/adapters/` + `__init__.py` 注册 |
-| 扩展 API | 先改 [api-contract.md](api-contract.md)，再同步 Java + Python |
+| 扩展 API | 先改 [api-contract.md](api-contract.md)，再实现 Java API；涉及执行协议时同步 Python Worker |
 | 队列可靠性 | `backend/app/worker/queue.py`、`backend/app/worker/monitor.py` |
 | 可观测性 | `backend/app/core/telemetry.py`、Java `RedMetricsFilter` |


### PR DESCRIPTION
## Summary

- pin each new Run to a server-owned immutable AgentVersion snapshot
- resolve pinned configuration in the Python Worker while keeping legacy unpinned Runs compatible
- add a lightweight backend-only Run comparison endpoint
- add Redis-backed regression executions that replay baseline inputs against one fixed current AgentVersion

## Behavior

- client-provided internal version metadata is overwritten by the Java API
- a pinned Run fails explicitly when its AgentVersion snapshot is missing
- historical Runs without a version pin continue to use the Agent's current config
- regression cases compare status and error; output changes are diagnostic and do not fail LLM-backed cases
- regression manifests are temporary Redis data, while Runs and execution results remain in PostgreSQL
- no database migration or frontend change is required

## API

- `POST /v1/run-comparisons/preview`
- `POST /v1/regression-executions`
- `GET /v1/regression-executions/{execution_id}`
- `GET /v1/regression-executions/{execution_id}/results`

## Validation

- Java: `RunComparisonServiceTest`, `RegressionExecutionServiceTest`, and `RunServiceTest`
- Python: 22 relevant AgentVersion, Run, Worker, and Tool Call lifecycle tests
- Ruff checks for all modified Python files
- `git diff --check`
