### PR TITLE
feat(frontend): add tool call inspector panel

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -32,7 +32,7 @@
 **目标：** 控制台调试闭环、事件可靠性与运行时指标。
 
 - [x] Step 时间线组件（节点延迟与状态流转）
-- [ ] 独立 ToolCall 检查面板（参数/结果/错误结构化浏览）
+- [x] 独立 ToolCall 检查面板（参数/结果/错误结构化浏览）
 - [x] SSE 事件重放（`Last-Event-ID` / 持久化 event log）
 - [x] 队列深度、worker 利用率导出为 OTel/Prometheus 指标
 - [x] p95 耗时仪表盘与告警

--- a/frontend/app/runs/[id]/page.tsx
+++ b/frontend/app/runs/[id]/page.tsx
@@ -9,6 +9,7 @@ import { EventStream } from "@/components/EventStream";
 import { StatusBadge } from "@/components/StatusBadge";
 import { StepTimeline } from "@/components/StepTimeline";
 import { TokenCostSummary } from "@/components/TokenCostSummary";
+import { ToolCallPanel } from "@/components/ToolCallPanel";
 import { checkpointsByStep } from "@/lib/checkpoints";
 import { api } from "@/lib/api";
 import { useRunWithLiveUpdates } from "@/lib/useRunLiveSync";
@@ -104,6 +105,8 @@ export default function RunDetailPage({ params }: PageProps) {
         steps={r.steps}
         checkpointsByStepId={stepCheckpoints}
       />
+
+      <ToolCallPanel steps={r.steps} />
 
       <section className="space-y-3">
         <h2 className="font-medium">Messages</h2>

--- a/frontend/components/ToolCallPanel.tsx
+++ b/frontend/components/ToolCallPanel.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import clsx from "clsx";
 import { useMemo } from "react";
 

--- a/frontend/components/ToolCallPanel.tsx
+++ b/frontend/components/ToolCallPanel.tsx
@@ -1,0 +1,143 @@
+import clsx from "clsx";
+
+import type { Step, ToolCall } from "@/lib/types";
+
+type ToolCallStatus = "pending" | "succeeded" | "failed";
+
+interface ToolCallEntry {
+  call: ToolCall;
+  stepIndex: number;
+  stepNode: string;
+}
+
+const statusStyle: Record<ToolCallStatus, string> = {
+  pending: "border-muted/40 bg-muted/10 text-muted",
+  succeeded: "border-good/40 bg-good/10 text-good",
+  failed: "border-bad/40 bg-bad/10 text-bad",
+};
+
+function getStatus(call: ToolCall): ToolCallStatus {
+  if (call.error != null) return "failed";
+  if (call.result != null) return "succeeded";
+  return "pending";
+}
+
+function formatLatency(ms: number | null): string | null {
+  if (ms == null) return null;
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
+}
+
+function JsonBlock({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div className="space-y-1">
+      <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
+      <pre className="max-h-72 overflow-auto rounded border border-border bg-bg p-3 text-xs font-mono whitespace-pre-wrap break-all text-muted">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export function ToolCallPanel({ steps }: { steps: Step[] }) {
+  const entries: ToolCallEntry[] = [...steps]
+    .sort((a, b) => a.index - b.index)
+    .flatMap((step) =>
+      step.tool_calls.map((call) => ({
+        call,
+        stepIndex: step.index,
+        stepNode: step.node,
+      })),
+    );
+
+  const counts: Record<ToolCallStatus, number> = {
+    pending: 0,
+    succeeded: 0,
+    failed: 0,
+  };
+  for (const { call } of entries) counts[getStatus(call)] += 1;
+
+  return (
+    <section className="rounded-lg border border-border bg-surface p-4 space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="font-medium">Tool calls</h2>
+          <p className="text-xs text-muted">
+            Inspect arguments, results, and errors across this run.
+          </p>
+        </div>
+        {entries.length > 0 ? (
+          <div className="flex flex-wrap gap-2 text-xs">
+            <span className="text-muted">{entries.length} total</span>
+            <span className="text-good">{counts.succeeded} succeeded</span>
+            <span className="text-bad">{counts.failed} failed</span>
+            <span className="text-muted">{counts.pending} pending</span>
+          </div>
+        ) : null}
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="rounded border border-dashed border-border p-4 text-center text-xs text-muted">
+          No tool calls recorded for this run.
+        </p>
+      ) : (
+        <ol className="space-y-2">
+          {entries.map(({ call, stepIndex, stepNode }) => {
+            const status = getStatus(call);
+            const latency = formatLatency(call.latency_ms);
+            return (
+              <li key={call.id}>
+                <details
+                  className="group rounded border border-border bg-bg"
+                  open={status === "failed"}
+                >
+                  <summary className="flex cursor-pointer list-none flex-wrap items-center gap-2 px-3 py-2.5 text-sm marker:content-none">
+                    <span className="font-medium text-accent">{call.name}</span>
+                    <span
+                      className={clsx(
+                        "rounded border px-1.5 py-0.5 text-[11px]",
+                        statusStyle[status],
+                      )}
+                    >
+                      {status}
+                    </span>
+                    {latency ? (
+                      <span className="text-xs font-mono text-muted">
+                        {latency}
+                      </span>
+                    ) : null}
+                    <span className="ml-auto text-xs font-mono text-muted">
+                      step #{stepIndex} · {stepNode}
+                    </span>
+                    <span
+                      className="text-muted transition-transform group-open:rotate-90"
+                      aria-hidden
+                    >
+                      ›
+                    </span>
+                  </summary>
+                  <div className="space-y-3 border-t border-border p-3">
+                    <JsonBlock label="Arguments" value={call.arguments} />
+                    {call.result != null ? (
+                      <JsonBlock label="Result" value={call.result} />
+                    ) : null}
+                    {call.error != null ? (
+                      <div className="space-y-1">
+                        <div className="text-xs uppercase tracking-wide text-bad">
+                          Error
+                        </div>
+                        <pre className="rounded border border-bad/40 bg-bad/10 p-3 text-xs font-mono whitespace-pre-wrap break-words text-bad">
+                          {call.error}
+                        </pre>
+                      </div>
+                    ) : null}
+                  </div>
+                </details>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/ToolCallPanel.tsx
+++ b/frontend/components/ToolCallPanel.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { useMemo } from "react";
 
 import type { Step, ToolCall } from "@/lib/types";
 
@@ -32,11 +33,13 @@ function formatLatency(ms: number | null): string | null {
 }
 
 function JsonBlock({ label, value }: { label: string; value: unknown }) {
+  const text = useMemo(() => JSON.stringify(value, null, 2), [value]);
+
   return (
     <div className="space-y-1">
       <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
       <pre className="max-h-72 overflow-auto rounded border border-border bg-bg p-3 text-xs font-mono whitespace-pre-wrap break-all text-muted">
-        {JSON.stringify(value, null, 2)}
+        {text}
       </pre>
     </div>
   );

--- a/frontend/components/ToolCallPanel.tsx
+++ b/frontend/components/ToolCallPanel.tsx
@@ -17,7 +17,7 @@ const statusStyle: Record<ToolCallStatus, string> = {
 };
 
 function getStatus(call: ToolCall): ToolCallStatus {
-  if (call.error != null) return "failed";
+  if (call.error) return "failed";
   if (call.result != null) return "succeeded";
   return "pending";
 }
@@ -25,7 +25,10 @@ function getStatus(call: ToolCall): ToolCallStatus {
 function formatLatency(ms: number | null): string | null {
   if (ms == null) return null;
   if (ms < 1000) return `${ms} ms`;
-  return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.round((ms % 60_000) / 1000);
+  return `${mins}m ${secs}s`;
 }
 
 function JsonBlock({ label, value }: { label: string; value: unknown }) {
@@ -87,10 +90,7 @@ export function ToolCallPanel({ steps }: { steps: Step[] }) {
             const latency = formatLatency(call.latency_ms);
             return (
               <li key={call.id}>
-                <details
-                  className="group rounded border border-border bg-bg"
-                  open={status === "failed"}
-                >
+                <details className="group rounded border border-border bg-bg">
                   <summary className="flex cursor-pointer list-none flex-wrap items-center gap-2 px-3 py-2.5 text-sm marker:content-none">
                     <span className="font-medium text-accent">{call.name}</span>
                     <span
@@ -121,7 +121,7 @@ export function ToolCallPanel({ steps }: { steps: Step[] }) {
                     {call.result != null ? (
                       <JsonBlock label="Result" value={call.result} />
                     ) : null}
-                    {call.error != null ? (
+                    {call.error ? (
                       <div className="space-y-1">
                         <div className="text-xs uppercase tracking-wide text-bad">
                           Error

--- a/frontend/components/ToolCallPanel.tsx
+++ b/frontend/components/ToolCallPanel.tsx
@@ -28,10 +28,10 @@ function getStatus(call: ToolCall): ToolCallStatus {
 function formatLatency(ms: number | null): string | null {
   if (ms == null) return null;
   if (ms < 1000) return `${ms} ms`;
-  const totalSeconds = Math.round(ms / 1000);
-  if (totalSeconds < 60) {
+  if (ms < 60_000) {
     return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
   }
+  const totalSeconds = Math.round(ms / 1000);
   const mins = Math.floor(totalSeconds / 60);
   const secs = totalSeconds % 60;
   return `${mins}m ${secs}s`;

--- a/frontend/components/ToolCallPanel.tsx
+++ b/frontend/components/ToolCallPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import clsx from "clsx";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import type { Step, ToolCall } from "@/lib/types";
 
@@ -18,6 +18,8 @@ const statusStyle: Record<ToolCallStatus, string> = {
   succeeded: "border-good/40 bg-good/10 text-good",
   failed: "border-bad/40 bg-bad/10 text-bad",
 };
+
+const JSON_PREVIEW_CHARS = 4_000;
 
 function getStatus(call: ToolCall): ToolCallStatus {
   if (call.error) return "failed";
@@ -38,14 +40,32 @@ function formatLatency(ms: number | null): string | null {
 }
 
 function JsonBlock({ label, value }: { label: string; value: unknown }) {
-  const text = useMemo(() => JSON.stringify(value, null, 2), [value]);
+  const text = useMemo(
+    () => JSON.stringify(value, null, 2) ?? String(value),
+    [value],
+  );
+  const [showAll, setShowAll] = useState(false);
+  const needsTruncate = text.length > JSON_PREVIEW_CHARS;
+  const visible =
+    !needsTruncate || showAll ? text : `${text.slice(0, JSON_PREVIEW_CHARS)}…`;
 
   return (
     <div className="space-y-1">
       <div className="text-xs uppercase tracking-wide text-muted">{label}</div>
       <pre className="max-h-72 overflow-auto rounded border border-border bg-bg p-3 text-xs font-mono whitespace-pre-wrap break-all text-muted">
-        {text}
+        {visible}
       </pre>
+      {needsTruncate ? (
+        <button
+          type="button"
+          className="text-xs text-accent hover:underline"
+          onClick={() => setShowAll((current) => !current)}
+        >
+          {showAll
+            ? "Show less"
+            : `Show all (${text.length.toLocaleString()} chars)`}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/frontend/components/ToolCallPanel.tsx
+++ b/frontend/components/ToolCallPanel.tsx
@@ -26,9 +26,12 @@ function getStatus(call: ToolCall): ToolCallStatus {
 function formatLatency(ms: number | null): string | null {
   if (ms == null) return null;
   if (ms < 1000) return `${ms} ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
-  const mins = Math.floor(ms / 60_000);
-  const secs = Math.round((ms % 60_000) / 1000);
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
+  }
+  const mins = Math.floor(totalSeconds / 60);
+  const secs = totalSeconds % 60;
   return `${mins}m ${secs}s`;
 }
 
@@ -46,22 +49,24 @@ function JsonBlock({ label, value }: { label: string; value: unknown }) {
 }
 
 export function ToolCallPanel({ steps }: { steps: Step[] }) {
-  const entries: ToolCallEntry[] = [...steps]
-    .sort((a, b) => a.index - b.index)
-    .flatMap((step) =>
-      step.tool_calls.map((call) => ({
-        call,
-        stepIndex: step.index,
-        stepNode: step.node,
-      })),
-    );
-
-  const counts: Record<ToolCallStatus, number> = {
-    pending: 0,
-    succeeded: 0,
-    failed: 0,
-  };
-  for (const { call } of entries) counts[getStatus(call)] += 1;
+  const { entries, counts } = useMemo(() => {
+    const entries: ToolCallEntry[] = [...steps]
+      .sort((a, b) => a.index - b.index)
+      .flatMap((step) =>
+        step.tool_calls.map((call) => ({
+          call,
+          stepIndex: step.index,
+          stepNode: step.node,
+        })),
+      );
+    const counts: Record<ToolCallStatus, number> = {
+      pending: 0,
+      succeeded: 0,
+      failed: 0,
+    };
+    for (const { call } of entries) counts[getStatus(call)] += 1;
+    return { entries, counts };
+  }, [steps]);
 
   return (
     <section className="rounded-lg border border-border bg-surface p-4 space-y-4">


### PR DESCRIPTION
## Summary

- add a dedicated Tool calls inspector to the run detail page
- show aggregate succeeded, failed, and pending counts with step context
- provide structured, expandable arguments/results and highlighted errors
- mark the corresponding Phase 2 roadmap item complete

This keeps the existing Step timeline behavior intact and uses the current `Run.steps[].tool_calls` contract, so no backend or API changes are required.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- browser QA at desktop and 390px widths, including succeeded/failed/pending calls and the empty state
