### PR TITLE
feat: add PydanticAI adapter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Alembic for persistence, and Redis for job queues and live events.
 
 ## Core capabilities
 
-- **Orchestrator adapters.** The default adapter uses LangGraph. Additional
-adapters can be registered for AutoGen, CrewAI, PydanticAI or internal
-frameworks without changing the API or database schema.
+- **Orchestrator adapters.** The default adapter uses LangGraph. The official
+PydanticAI integration ships as an installable plugin, and additional adapters
+can be registered for AutoGen, CrewAI or internal frameworks without changing
+the API or database schema.
 - **Persistent execution model.** `Run`, `Step`, `Message`, `ToolCall` and
 `Checkpoint` are first-class database entities. They provide a common
 observability surface across different orchestration engines.
@@ -202,6 +203,12 @@ class MyAdapter(OrchestratorAdapter):
 Register the adapter in `app/adapters/__init__.py`. Workers pick it up
 automatically; the API, persistence model, event stream and console stay on
 the shared runtime contract.
+
+Official adapters can also ship as entry-point plugins. The PydanticAI package
+in [`integrations/pydantic-ai`](integrations/pydantic-ai) loads an existing
+PydanticAI Agent through a trusted factory and maps its streamed text, output,
+model usage, and native tool/MCP events onto the same contract without adding
+PydanticAI to the core backend dependency set.
 
 ## Current architecture (summary)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,8 +35,9 @@ Python worker 执行 adapter，SQLAlchemy + Alembic 负责持久化，Redis 负�
 
 ## 核心能力
 
-- **编排 adapter。** 默认 adapter 使用 LangGraph。AutoGen、CrewAI、
-PydanticAI 或内部框架可以通过相同接口注册接入，不需要修改 API 或数据库模型。
+- **编排 adapter。** 默认 adapter 使用 LangGraph。官方 PydanticAI 集成以
+可安装插件提供；AutoGen、CrewAI 或内部框架也可以通过相同接口注册接入，
+不需要修改 API 或数据库模型。
 - **持久化执行模型。** `Run`、`Step`、`Message`、`ToolCall` 和 `Checkpoint`
 是一等数据库实体，为不同编排引擎提供统一的可观测数据面。
 - **Server-Sent Events。** run 生命周期中的状态变化会被发布为 SSE 事件，
@@ -171,6 +172,12 @@ class MyAdapter(OrchestratorAdapter):
 
 在 `app/adapters/__init__.py` 中注册 adapter。Worker 会自动加载；
 API、持久化模型、事件流和控制台继续通过统一的运行时契约工作。
+
+官方 adapter 也可以通过 entry point 以插件包发布。
+[`integrations/pydantic-ai`](integrations/pydantic-ai) 中的 PydanticAI 包会将
+用户通过受信任 factory 提供的现有 Agent 所产生的流式文本、输出、模型
+usage 及原生工具/MCP 事件映射到同一契约，同时不向核心 backend 增加
+PydanticAI 依赖。
 
 ## 当前架构（摘要）
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,14 @@ exactly as it was.
 No changes are needed in the DB schema, the `/v1` contract, or the frontend.
 Workers pick up new adapters through the shared Python adapter registry.
 
+The repository's official PydanticAI integration follows this layout in
+`integrations/pydantic-ai`. Its `pydantic-ai` entry point keeps PydanticAI and
+provider dependencies optional. A trusted `agent_factory` supplies an existing
+Agent, including its instructions, output validators, native tools, and MCP
+toolsets. One PydanticAI run maps to one runtime step; token deltas, output,
+provider usage/cost, and tool events are translated to standard adapter events.
+The MVP does not rebuild Agents from JSON or implement checkpoint/resume.
+
 ## Unit tests
 
 The Python test suite in `backend/tests/` exercises adapter and queue logic

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -46,7 +46,7 @@
 **目标：** 第三方框架与工具可插拔，无需 fork runtime。
 
 - [x] Adapter 插件注册表（entry points / 动态加载）
-- [ ] 官方 adapter：AutoGen、CrewAI、PydanticAI（PydanticAI 已完成；按需求再选 1 个）
+- [ ] 官方 adapter：AutoGen、CrewAI、PydanticAI（按需求选 2 个）
 - [ ] MCP tool adapter
 - [ ] OpenAPI 规范 + Python/TypeScript SDK 自动生成
 - [ ] Webhook 出站事件（`run.completed` 等）

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -46,7 +46,7 @@
 **目标：** 第三方框架与工具可插拔，无需 fork runtime。
 
 - [x] Adapter 插件注册表（entry points / 动态加载）
-- [ ] 官方 adapter：AutoGen、CrewAI、PydanticAI（按需求选 2 个）
+- [ ] 官方 adapter：AutoGen、CrewAI、PydanticAI（PydanticAI 已完成；按需求再选 1 个）
 - [ ] MCP tool adapter
 - [ ] OpenAPI 规范 + Python/TypeScript SDK 自动生成
 - [ ] Webhook 出站事件（`run.completed` 等）

--- a/integrations/pydantic-ai/README.md
+++ b/integrations/pydantic-ai/README.md
@@ -1,0 +1,74 @@
+# AgentFlow PydanticAI adapter
+
+This optional plugin runs an existing PydanticAI `Agent` and translates its
+text stream, usage, result, and native tool/MCP events to AgentFlow's shared
+runtime contract.
+
+## Install
+
+Install the backend and plugin in every Python worker, then restart the worker
+so entry-point discovery runs again:
+
+```bash
+pip install agentflow agentflow-pydantic-ai
+```
+
+From this repository:
+
+```bash
+pip install -e ./backend -e ./integrations/pydantic-ai
+```
+
+The package registers `pydantic-ai` in the `agentflow.adapters` entry-point
+group. It does not add PydanticAI to AgentFlow's core dependencies.
+
+## Define the Agent
+
+Expose a zero-argument factory from code installed in the worker environment:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPToolset
+
+
+def create_agent() -> Agent:
+    knowledge = MCPToolset("knowledge_server.py")
+    return Agent(
+        "openai:gpt-4o-mini",
+        instructions="Use the knowledge base when helpful.",
+        toolsets=[knowledge],
+    )
+```
+
+The factory owns the PydanticAI model, instructions, tools, MCP servers,
+validators, and output type. Returning a fresh Agent per run avoids accidental
+state sharing between runs.
+
+Install the MCP client extra when the factory uses `MCPToolset`:
+
+```bash
+pip install "agentflow-pydantic-ai[mcp]"
+```
+
+## AgentFlow config
+
+```json
+{
+  "adapter": "pydantic-ai",
+  "config": {
+    "agent_factory": "myapp.agents:create_agent"
+  }
+}
+```
+
+`agent_factory` imports and executes trusted Python code in the worker process.
+Only administrators should be allowed to configure it; this plugin is not a
+sandbox.
+
+One PydanticAI run maps to one AgentFlow step. The plugin emits user and
+assistant messages, token deltas, provider usage/cost when available, and
+AgentFlow-owned ToolCall IDs for PydanticAI function-tool and MCP events.
+
+The MVP deliberately does not rebuild Agents from JSON, route tools through
+`AdapterToolSurface`, or implement checkpoint/retry, HITL, and deferred tools.
+PydanticAI 2.27 or later in the 2.x series is supported.

--- a/integrations/pydantic-ai/pyproject.toml
+++ b/integrations/pydantic-ai/pyproject.toml
@@ -1,0 +1,50 @@
+[project]
+name = "agentflow-pydantic-ai"
+version = "0.1.0"
+description = "Official PydanticAI adapter plugin for AgentFlow"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "Apache-2.0" }
+dependencies = [
+    "agentflow>=0.1.0,<0.2.0",
+    "pydantic-ai-slim[openai]>=2.27,<3.0",
+]
+
+[project.entry-points."agentflow.adapters"]
+pydantic-ai = "agentflow_pydantic_ai:create_adapter"
+
+[project.optional-dependencies]
+mcp = [
+    "pydantic-ai-slim[mcp]>=2.27,<3.0",
+]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.7",
+    "mypy>=1.13",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentflow_pydantic_ai"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "ASYNC", "RUF"]
+ignore = ["E501", "RUF002", "RUF003"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = false
+ignore_missing_imports = true
+disable_error_code = ["import-untyped"]

--- a/integrations/pydantic-ai/src/agentflow_pydantic_ai/__init__.py
+++ b/integrations/pydantic-ai/src/agentflow_pydantic_ai/__init__.py
@@ -1,0 +1,10 @@
+"""Official PydanticAI adapter plugin for AgentFlow."""
+
+from agentflow_pydantic_ai.adapter import PydanticAIAdapter
+
+__all__ = ["PydanticAIAdapter", "create_adapter"]
+
+
+def create_adapter() -> PydanticAIAdapter:
+    """Entry-point factory discovered through ``agentflow.adapters``."""
+    return PydanticAIAdapter()

--- a/integrations/pydantic-ai/src/agentflow_pydantic_ai/adapter.py
+++ b/integrations/pydantic-ai/src/agentflow_pydantic_ai/adapter.py
@@ -1,0 +1,202 @@
+"""Run an existing PydanticAI agent on AgentFlow's adapter surface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from importlib import import_module
+from typing import Any
+
+from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
+from app.core.logging import get_logger
+from app.models.run import RunStatus
+from pydantic_ai import (
+    Agent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    PartDeltaEvent,
+    PartStartEvent,
+    RetryPromptPart,
+    TextPart,
+    TextPartDelta,
+    ToolReturnPart,
+)
+from pydantic_core import to_jsonable_python
+
+logger = get_logger("adapter.pydantic_ai")
+
+DEFAULT_NODE = "pydantic_ai"
+
+
+class PydanticAIAdapter(OrchestratorAdapter):
+    """Load a trusted Agent factory and translate one run into one step."""
+
+    name = "pydantic-ai"
+
+    async def run(self, ctx: AdapterContext) -> AdapterResult:
+        step_index = ctx.step_index_base
+        node = str(ctx.agent_config.get("node") or DEFAULT_NODE)
+        prompt = prompt_from_input(ctx.input)
+        active_tools: dict[str, tuple[str, str, float]] = {}
+
+        await ctx.emit_step_started(index=step_index, node=node)
+        await ctx.emit_message(role="user", content=prompt)
+        started = time.monotonic()
+
+        try:
+            agent = load_agent(ctx.agent_config.get("agent_factory"))
+
+            async with agent.run_stream_events(
+                prompt,
+                run_id=ctx.run_id,
+                metadata=dict(ctx.metadata) or None,
+            ) as events:
+                async for event in events:
+                    if delta := text_delta(event):
+                        await ctx.emit_token_delta(step_index=step_index, delta=delta)
+                    elif isinstance(event, FunctionToolCallEvent):
+                        call_id = await ctx.emit_tool_call_started(
+                            step_index=step_index,
+                            name=event.part.tool_name,
+                            arguments=event.part.args_as_dict(),
+                        )
+                        active_tools[event.tool_call_id] = (
+                            event.part.tool_name,
+                            call_id,
+                            time.monotonic(),
+                        )
+                    elif isinstance(event, FunctionToolResultEvent):
+                        await emit_tool_result(ctx, step_index, event, active_tools)
+                result = events.result
+
+            if result is None:
+                raise RuntimeError("PydanticAI run ended without a final result")
+
+            output = adapter_output(result.output)
+            usage = result.usage
+            metrics: dict[str, Any] = {
+                "tokens_in": int(usage.input_tokens),
+                "tokens_out": int(usage.output_tokens),
+                "latency_ms": int((time.monotonic() - started) * 1000),
+                "requests": int(usage.requests),
+            }
+            if usage.cost is not None:
+                metrics["cost_usd"] = float(usage.cost)
+
+            await ctx.emit_message(role="assistant", content=output["reply"])
+            await ctx.emit_step_completed(
+                index=step_index,
+                node=node,
+                output=output,
+                **metrics,
+            )
+            return AdapterResult(status=RunStatus.SUCCEEDED, output=output)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception("pydantic_ai_run_failed", run_id=ctx.run_id)
+            error = str(exc) or type(exc).__name__
+            await close_active_tools(ctx, step_index, active_tools, error)
+            await ctx.emit_step_failed(index=step_index, node=node, error=error)
+            return AdapterResult(status=RunStatus.FAILED, error=error)
+
+
+def load_agent(reference: Any) -> Agent[Any, Any]:
+    """Load ``module:factory`` from trusted worker code and create an Agent."""
+    if not isinstance(reference, str) or not reference.strip():
+        raise ValueError("agent_factory must be a non-empty 'module:factory' string")
+
+    module_name, separator, factory_name = reference.strip().partition(":")
+    if not separator or not module_name or not factory_name:
+        raise ValueError("agent_factory must use the 'module:factory' format")
+
+    factory = getattr(import_module(module_name), factory_name, None)
+    if not callable(factory):
+        raise TypeError(f"agent_factory {reference!r} is not callable")
+
+    agent = factory()
+    if not isinstance(agent, Agent):
+        raise TypeError(f"agent_factory {reference!r} must return pydantic_ai.Agent")
+    return agent
+
+
+async def emit_tool_result(
+    ctx: AdapterContext,
+    step_index: int,
+    event: FunctionToolResultEvent,
+    active_tools: dict[str, tuple[str, str, float]],
+) -> None:
+    """Pair provider tool IDs locally while persisting AgentFlow-owned ULIDs."""
+    provider_id = event.tool_call_id
+    active = active_tools.pop(provider_id, None)
+    name = event.part.tool_name or (active[0] if active else "unknown")
+    if active is None:
+        call_id = await ctx.emit_tool_call_started(
+            step_index=step_index,
+            name=name,
+            arguments={},
+        )
+        tool_started = time.monotonic()
+    else:
+        _, call_id, tool_started = active
+
+    result, error = tool_result(event.part)
+    await ctx.emit_tool_call_completed(
+        step_index=step_index,
+        name=name,
+        call_id=call_id,
+        result=result,
+        error=error,
+        latency_ms=int((time.monotonic() - tool_started) * 1000),
+    )
+
+
+async def close_active_tools(
+    ctx: AdapterContext,
+    step_index: int,
+    active_tools: dict[str, tuple[str, str, float]],
+    error: str,
+) -> None:
+    for name, call_id, tool_started in active_tools.values():
+        await ctx.emit_tool_call_completed(
+            step_index=step_index,
+            name=name,
+            call_id=call_id,
+            error=error,
+            latency_ms=int((time.monotonic() - tool_started) * 1000),
+        )
+
+
+def tool_result(part: ToolReturnPart | RetryPromptPart) -> tuple[dict[str, Any], str | None]:
+    value = to_jsonable_python(part.content, fallback=str)
+    result = value if isinstance(value, dict) else {"result": value}
+    if isinstance(part, RetryPromptPart):
+        return result, part.model_response()
+    if part.outcome != "success":
+        return result, part.model_response_str(wrap_if_error=False)
+    return result, None
+
+
+def text_delta(event: Any) -> str | None:
+    if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+        return event.part.content
+    if isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+        return event.delta.content_delta
+    return None
+
+
+def prompt_from_input(run_input: dict[str, Any]) -> str:
+    for key in ("prompt", "message", "text", "input"):
+        if key in run_input:
+            value = run_input[key]
+            return value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+    return json.dumps(run_input, ensure_ascii=False)
+
+
+def adapter_output(value: Any) -> dict[str, Any]:
+    normalized = to_jsonable_python(value, fallback=str)
+    if isinstance(normalized, str):
+        return {"reply": normalized}
+    reply = json.dumps(normalized, ensure_ascii=False, separators=(",", ":"))
+    return {"reply": reply, "structured_output": normalized}

--- a/integrations/pydantic-ai/tests/test_adapter.py
+++ b/integrations/pydantic-ai/tests/test_adapter.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from app.adapters.base import AdapterContext
+from app.models.run import RunStatus
+from pydantic_ai import Agent
+from pydantic_ai.models.function import DeltaToolCall, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from agentflow_pydantic_ai import PydanticAIAdapter, create_adapter
+
+
+class RecordingContext(AdapterContext):
+    def __init__(self, agent_factory: str) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+        super().__init__(
+            run_id="01PYDANTICAI",
+            agent_id="01AGENT",
+            agent_config={"agent_factory": agent_factory},
+            input={"prompt": "hello"},
+            emit=self._emit,
+        )
+
+    async def _emit(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+
+    def event(self, event_type: str) -> list[dict[str, Any]]:
+        return [data for current, data in self.events if current == event_type]
+
+
+def factory_reference(name: str) -> str:
+    return f"{__name__}:{name}"
+
+
+def text_agent() -> Agent[None, str]:
+    return Agent(TestModel(custom_output_text="Hello from PydanticAI"))
+
+
+def tool_agent() -> Agent[None, str]:
+    requests = 0
+
+    async def stream_model(_messages: list[Any], _info: Any):
+        nonlocal requests
+        requests += 1
+        if requests == 1:
+            yield {
+                0: DeltaToolCall(
+                    name="echo",
+                    json_args='{"text":"ping"}',
+                    tool_call_id="provider-call-id-that-is-not-a-ulid",
+                )
+            }
+        else:
+            yield "tool finished"
+
+    agent = Agent(FunctionModel(stream_function=stream_model))
+
+    @agent.tool_plain
+    async def echo(text: str) -> dict[str, str]:
+        return {"text": text}
+
+    return agent
+
+
+def not_an_agent() -> object:
+    return object()
+
+
+@pytest.mark.asyncio
+async def test_factory_run_streams_messages_and_usage() -> None:
+    adapter = create_adapter()
+    ctx = RecordingContext(factory_reference("text_agent"))
+
+    result = await adapter.run(ctx)
+
+    assert isinstance(adapter, PydanticAIAdapter)
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output == {"reply": "Hello from PydanticAI"}
+    assert ctx.event("step.started") == [{"index": 0, "node": "pydantic_ai"}]
+    assert "".join(item["delta"] for item in ctx.event("token.delta")) == ("Hello from PydanticAI")
+    assert [item["role"] for item in ctx.event("message.created")] == [
+        "user",
+        "assistant",
+    ]
+    assert ctx.event("step.completed")[0]["tokens_in"] > 0
+    assert ctx.event("step.completed")[0]["output"] == result.output
+
+
+@pytest.mark.asyncio
+async def test_native_tool_events_use_agentflow_ids() -> None:
+    ctx = RecordingContext(factory_reference("tool_agent"))
+
+    result = await PydanticAIAdapter().run(ctx)
+
+    assert result.status == RunStatus.SUCCEEDED
+    started = ctx.event("tool_call.started")[0]
+    completed = ctx.event("tool_call.completed")[0]
+    assert started["name"] == "echo"
+    assert started["arguments"] == {"text": "ping"}
+    assert len(started["call_id"]) == 26
+    assert started["call_id"] != "provider-call-id-that-is-not-a-ulid"
+    assert completed["call_id"] == started["call_id"]
+    assert completed["result"] == {"text": "ping"}
+    assert completed["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_factory_becomes_a_failed_step() -> None:
+    ctx = RecordingContext(factory_reference("not_an_agent"))
+
+    result = await PydanticAIAdapter().run(ctx)
+
+    assert result.status == RunStatus.FAILED
+    assert "must return pydantic_ai.Agent" in (result.error or "")
+    assert ctx.event("step.failed")[0]["error"] == result.error


### PR DESCRIPTION
## Summary

- add an independently installable `agentflow-pydantic-ai` adapter package
- discover the adapter through the `agentflow.adapters` entry-point group
- load an existing PydanticAI `Agent` from a worker-side factory
- translate streamed text, final output, usage/cost, and function-tool events to AgentFlow adapter events
- document installation, configuration, architecture, and MVP limitations

## Why

This advances the Phase 3 goal of adding framework adapters without changing the runtime, database schema, API contract, or frontend. Applications retain ownership of their PydanticAI model, instructions, tools, MCP toolsets, validators, and output type.

## Validation

- 15 adapter and plugin-discovery tests passed with warnings treated as errors
- Ruff check and format check passed
- Mypy passed
- verified against PydanticAI 2.27 and 2.31
- wheel build and `agentflow.adapters` entry-point metadata verified

## MVP boundaries

- one PydanticAI run maps to one AgentFlow step
- checkpoint-aware retry/resume, HITL, deferred tools, and `AdapterToolSurface` integration are not implemented
- factories are synchronous, zero-argument callables installed in the worker environment

The current tests prove the shared function-tool event path. A dedicated MCP smoke test and plugin CI job are follow-up items before marking this ready for review.
