### PR TITLE
feat: introduce MCP tool adapter for direct tool invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ and shared infrastructure.
 | Console  | Next.js 15, React Query, SSE  | Run/agent management, live event stream                |
 | API      | Java 21, Spring Boot 3, JPA   | REST `/v1/*`, SSE bridge, job enqueue, cancel          |
 | Worker   | Python asyncio, `RunExecutor` | Consume Redis jobs, run adapters, write Postgres       |
-| Adapters | LangGraph, Echo (+ registry)  | Framework-specific orchestration behind one interface  |
+| Adapters | LangGraph, Echo, MCP (+ registry)  | Framework-specific orchestration behind one interface  |
 | State    | Postgres 16, Alembic          | Durable runs, steps, messages, tool calls, checkpoints |
 | Messaging| Redis Streams + pub/sub       | At-least-once job queue, cancel keys, live events      |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,7 +189,7 @@ AgentFlow 是**分层运行时**：Java API 层、Python 执行层、共享基�
 | 控制台    | Next.js 15、React Query、SSE   | Agent/Run 管理、实时事件流                   |
 | API      | Java 21、Spring Boot 3、JPA    | REST `/v1/*`、SSE 桥接、入队、取消            |
 | Worker   | Python asyncio、`RunExecutor` | 消费 Redis 任务、执行 adapter、写 Postgres    |
-| Adapter  | LangGraph、Echo（可注册）          | 统一接口下的框架编排                           |
+| Adapter  | LangGraph、Echo、MCP（可注册）       | 统一接口下的框架编排                           |
 | 状态     | Postgres 16、Alembic          | Run、Step、Message、ToolCall、Checkpoint |
 | 消息     | Redis Streams + pub/sub      | 至少一次任务队列、取消信号、实时事件                   |
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,7 +7,7 @@ orchestrator adapter.
 
 ```
 app/
-├── adapters/         Orchestrator adapters (Echo, LangGraph, ...)
+├── adapters/         Orchestrator adapters (Echo, LangGraph, MCP, ...)
 ├── api/v1/           HTTP routes
 ├── core/             Config + logging
 ├── db/               SQLAlchemy session/base
@@ -28,6 +28,14 @@ uv run uvicorn app.main:app --reload
 ```
 
 Browse OpenAPI at http://localhost:8000/docs.
+
+### MCP tool adapter
+
+The `mcp` adapter calls MCP servers directly (stdio, SSE, or Streamable HTTP)
+and writes standard `ToolCall` rows. Configure `mcp_servers` in agent config
+and pass tool calls via `input.tool`/`input.calls` or fixed `config.steps`.
+LangGraph graphs can reuse the same MCP bridge via `AdapterToolSurface`.
+See [docs/architecture.md](../docs/architecture.md#mcp-tool-bridge).
 
 ## Tests
 

--- a/backend/app/adapters/__init__.py
+++ b/backend/app/adapters/__init__.py
@@ -22,6 +22,7 @@ from app.adapters.base import (
 from app.adapters.discovery import AdapterPluginError, load_adapter_plugins
 from app.adapters.echo_adapter import EchoAdapter
 from app.adapters.langgraph_adapter import LangGraphAdapter
+from app.adapters.mcp_adapter import McpAdapter
 from app.adapters.mcp_client import (
     McpServerConfig,
     McpSessionManager,
@@ -38,6 +39,7 @@ from app.adapters.tool_registry import (
 
 register_adapter("echo", EchoAdapter())
 register_adapter("langgraph", LangGraphAdapter())
+register_adapter("mcp", McpAdapter())
 
 __all__ = [
     "AdapterContext",
@@ -45,6 +47,7 @@ __all__ = [
     "AdapterToolSurface",
     "EchoAdapter",
     "LangGraphAdapter",
+    "McpAdapter",
     "McpServerConfig",
     "McpSessionManager",
     "OrchestratorAdapter",

--- a/backend/app/adapters/mcp_adapter.py
+++ b/backend/app/adapters/mcp_adapter.py
@@ -1,0 +1,166 @@
+"""MCP tool adapter – direct MCP invocation without an LLM orchestrator.
+
+Use this adapter when a run should call one or more MCP tools and persist
+standard ``ToolCall`` rows, without LangGraph or another framework in the loop.
+
+Expected agent.config shape::
+
+    {
+      "mcp_servers": [
+        {
+          "name": "echo",
+          "transport": "stdio",
+          "command": "python",
+          "args": ["path/to/mcp_server.py"]
+        }
+      ],
+      "tools": ["mcp/echo/ping"],   // optional whitelist
+      "mcp_auto_register": false,
+      "steps": [                    // optional fixed sequence
+        {"tool": "mcp/echo/ping", "arguments": {"message": "hello"}}
+      ]
+    }
+
+Run ``input`` when ``steps`` is omitted::
+
+    {"tool": "mcp/echo/ping", "arguments": {"message": "hello"}}
+
+Batch form::
+
+    {
+      "calls": [
+        {"tool": "mcp/echo/ping", "arguments": {"message": "hello"}},
+        {"tool": "mcp/echo/add", "arguments": {"a": 1, "b": 2}}
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.adapters.adapter_tools import open_tool_surface
+from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
+from app.adapters.mcp_client import is_mcp_tool_key
+from app.core.logging import get_logger
+from app.models.run import RunStatus
+
+logger = get_logger("adapter.mcp")
+
+
+def _parse_tool_calls(
+    agent_config: dict[str, Any], run_input: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Resolve the tool call sequence from agent config or run input."""
+    raw_steps = agent_config.get("steps")
+    if raw_steps is not None:
+        if not isinstance(raw_steps, list) or not raw_steps:
+            raise ValueError("agent.config.steps must be a non-empty list")
+        return [_normalize_call(entry, index) for index, entry in enumerate(raw_steps)]
+
+    raw_calls = run_input.get("calls")
+    if raw_calls is not None:
+        if not isinstance(raw_calls, list) or not raw_calls:
+            raise ValueError("input.calls must be a non-empty list")
+        return [_normalize_call(entry, index) for index, entry in enumerate(raw_calls)]
+
+    if "tool" in run_input:
+        return [_normalize_call(run_input, 0)]
+
+    raise ValueError(
+        "MCP adapter requires agent.config.steps or run input with "
+        "'tool'/'arguments' or a non-empty 'calls' list"
+    )
+
+
+def _normalize_call(entry: Any, index: int) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise ValueError(f"tool call at index {index} must be an object")
+    tool = entry.get("tool")
+    if not tool or not isinstance(tool, str):
+        raise ValueError(f"tool call at index {index} requires a string 'tool'")
+    arguments = entry.get("arguments")
+    if arguments is None:
+        arguments = {}
+    if not isinstance(arguments, dict):
+        raise ValueError(f"tool call at index {index}: 'arguments' must be an object")
+    return {"tool": tool, "arguments": arguments}
+
+
+class McpAdapter(OrchestratorAdapter):
+    """Invoke MCP tools directly and emit standard ToolCall lifecycle events."""
+
+    name = "mcp"
+
+    async def run(self, ctx: AdapterContext) -> AdapterResult:
+        try:
+            calls = _parse_tool_calls(ctx.agent_config, ctx.input)
+        except ValueError as exc:
+            return AdapterResult(status=RunStatus.FAILED, error=str(exc))
+
+        for call in calls:
+            if not is_mcp_tool_key(call["tool"]):
+                return AdapterResult(
+                    status=RunStatus.FAILED,
+                    error=(
+                        f"MCP adapter only supports MCP tool keys "
+                        f"(mcp/{{server}}/{{tool}}); got {call['tool']!r}"
+                    ),
+                )
+
+        tool_keys = list({call["tool"] for call in calls})
+        configured_keys = list(ctx.agent_config.get("tools") or [])
+        resolve_keys = configured_keys or tool_keys
+
+        try:
+            async with open_tool_surface(ctx.agent_config, resolve_keys) as surface:
+                results: list[dict[str, Any]] = []
+                for index, call in enumerate(calls):
+                    step_index = ctx.step_index_base + index
+                    tool_name = call["tool"]
+                    arguments = call["arguments"]
+                    node = tool_name.rsplit("/", 1)[-1]
+
+                    await ctx.emit_step_started(index=step_index, node=node)
+                    try:
+                        result = await surface.execute(
+                            ctx,
+                            step_index=step_index,
+                            name=tool_name,
+                            arguments=arguments,
+                        )
+                    except Exception as exc:
+                        await ctx.emit_step_failed(
+                            index=step_index,
+                            node=node,
+                            error=str(exc),
+                        )
+                        return AdapterResult(
+                            status=RunStatus.FAILED,
+                            error=str(exc),
+                        )
+
+                    results.append(
+                        {"tool": tool_name, "arguments": arguments, "result": result}
+                    )
+                    await ctx.emit_step_completed(
+                        index=step_index,
+                        node=node,
+                        output={"tool": tool_name, "result": result},
+                    )
+                    logger.info(
+                        "mcp_tool.completed",
+                        tool=tool_name,
+                        step_index=step_index,
+                    )
+
+                output = (
+                    results[0]
+                    if len(results) == 1
+                    else {"calls": results, "count": len(results)}
+                )
+                return AdapterResult(status=RunStatus.SUCCEEDED, output=output)
+        except KeyError as exc:
+            return AdapterResult(status=RunStatus.FAILED, error=str(exc))
+        except RuntimeError as exc:
+            return AdapterResult(status=RunStatus.FAILED, error=str(exc))

--- a/backend/app/adapters/mcp_client.py
+++ b/backend/app/adapters/mcp_client.py
@@ -102,7 +102,7 @@ def serialize_call_tool_result(result: Any) -> dict[str, Any]:
             content_blocks.append({"type": str(block_type), "raw": str(block)})
 
     payload: dict[str, Any] = {"content": content_blocks}
-    if getattr(result, "isError", False):
+    if getattr(result, "isError", False) or getattr(result, "is_error", False):
         payload["is_error"] = True
     structured = getattr(result, "structuredContent", None)
     if structured is not None:
@@ -208,7 +208,11 @@ class McpSessionManager:
     ) -> dict[str, Any]:
         session = await self._require_session(server_name)
         result = await session.call_tool(tool_name, arguments)
-        return serialize_call_tool_result(result)
+        payload = serialize_call_tool_result(result)
+        if payload.get("is_error"):
+            message = payload.get("text") or f"MCP tool {tool_name!r} returned an error"
+            raise RuntimeError(message)
+        return payload
 
     async def _require_session(self, server_name: str) -> Any:
         if server_name not in self._servers:

--- a/backend/app/adapters/mcp_tools.py
+++ b/backend/app/adapters/mcp_tools.py
@@ -116,10 +116,14 @@ async def _build_mcp_tool_definitions(
         server_name, tool_name = parse_mcp_tool_key(key)
         meta = await manager.get_tool_meta(server_name, tool_name)
         handler = _make_mcp_handler(manager, server_name, tool_name)
-        parameters = getattr(meta, "inputSchema", None) or {
-            "type": "object",
-            "properties": {},
-        }
+        parameters = (
+            getattr(meta, "inputSchema", None)
+            or getattr(meta, "input_schema", None)
+            or {
+                "type": "object",
+                "properties": {},
+            }
+        )
         definitions.append(
             ToolDefinition(
                 name=key,

--- a/backend/tests/fixtures/mcp_echo_server.py
+++ b/backend/tests/fixtures/mcp_echo_server.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-import mcp_types as types
-from mcp.server.lowlevel.server import Server
-from mcp.server.stdio import stdio_server
+import mcp.types as types
 
 _TOOLS = [
     types.Tool(

--- a/backend/tests/fixtures/mcp_echo_server.py
+++ b/backend/tests/fixtures/mcp_echo_server.py
@@ -1,21 +1,72 @@
 """Minimal MCP server used by integration tests."""
 
-from mcp.server.fastmcp import FastMCP
+from __future__ import annotations
 
-mcp = FastMCP("echo-test")
+import asyncio
+
+import mcp_types as types
+from mcp.server.lowlevel.server import Server
+from mcp.server.stdio import stdio_server
+
+_TOOLS = [
+    types.Tool(
+        name="ping",
+        description="Echo a message back.",
+        input_schema={
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+        },
+    ),
+    types.Tool(
+        name="add",
+        description="Add two integers.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+        },
+    ),
+]
 
 
-@mcp.tool()
-def ping(message: str = "ping") -> str:
-    """Echo a message back."""
-    return message
+async def _list_tools(_ctx, _params) -> types.ListToolsResult:
+    return types.ListToolsResult(tools=_TOOLS)
 
 
-@mcp.tool()
-def add(a: int, b: int) -> int:
-    """Add two integers."""
-    return a + b
+async def _call_tool(_ctx, params: types.CallToolRequestParams) -> types.CallToolResult:
+    arguments = params.arguments or {}
+    if params.name == "ping":
+        message = str(arguments.get("message", "ping"))
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=message)]
+        )
+    if params.name == "add":
+        total = int(arguments.get("a", 0)) + int(arguments.get("b", 0))
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=str(total))]
+        )
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=f"unknown tool {params.name!r}")],
+        is_error=True,
+    )
+
+
+async def _main() -> None:
+    server = Server(
+        "echo-test",
+        on_list_tools=_list_tools,
+        on_call_tool=_call_tool,
+    )
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
 
 
 if __name__ == "__main__":
-    mcp.run()
+    asyncio.run(_main())

--- a/backend/tests/test_mcp_adapter.py
+++ b/backend/tests/test_mcp_adapter.py
@@ -1,0 +1,138 @@
+"""Tests for the MCP tool adapter."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.adapters.base import AdapterContext
+from app.adapters.mcp_adapter import McpAdapter, _parse_tool_calls
+from app.models.run import RunStatus
+
+_FIXTURE_SERVER = Path(__file__).resolve().parent / "fixtures" / "mcp_echo_server.py"
+
+
+class _RecordingContext(AdapterContext):
+    def __init__(self, **kwargs: Any) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+        super().__init__(
+            run_id="01TEST",
+            agent_id="01AGENT",
+            agent_config=kwargs.pop("agent_config", {}),
+            input=kwargs.pop("input", {"prompt": "hello"}),
+            emit=self._emit,
+            **kwargs,
+        )
+
+    async def _emit(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+
+
+def _mcp_server_config() -> dict[str, Any]:
+    return {
+        "name": "echo",
+        "transport": "stdio",
+        "command": sys.executable,
+        "args": [str(_FIXTURE_SERVER)],
+    }
+
+
+def test_parse_tool_calls_from_input():
+    calls = _parse_tool_calls({}, {"tool": "mcp/echo/ping", "arguments": {"message": "hi"}})
+    assert calls == [{"tool": "mcp/echo/ping", "arguments": {"message": "hi"}}]
+
+
+def test_parse_tool_calls_from_batch():
+    calls = _parse_tool_calls(
+        {},
+        {
+            "calls": [
+                {"tool": "mcp/echo/ping", "arguments": {"message": "a"}},
+                {"tool": "mcp/echo/add", "arguments": {"a": 1, "b": 2}},
+            ]
+        },
+    )
+    assert len(calls) == 2
+
+
+def test_parse_tool_calls_from_config_steps():
+    calls = _parse_tool_calls(
+        {"steps": [{"tool": "mcp/echo/ping", "arguments": {"message": "x"}}]},
+        {},
+    )
+    assert calls[0]["tool"] == "mcp/echo/ping"
+
+
+def test_parse_tool_calls_requires_input():
+    with pytest.raises(ValueError, match="requires agent.config.steps"):
+        _parse_tool_calls({}, {})
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_single_tool_call():
+    adapter = McpAdapter()
+    ctx = _RecordingContext(
+        agent_config={"mcp_servers": [_mcp_server_config()]},
+        input={"tool": "mcp/echo/ping", "arguments": {"message": "hello"}},
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output["result"]["text"] == "hello"
+
+    started = [d for e, d in ctx.events if e == "tool_call.started"]
+    completed = [d for e, d in ctx.events if e == "tool_call.completed"]
+    assert len(started) == 1
+    assert started[0]["name"] == "mcp/echo/ping"
+    assert len(completed) == 1
+    assert completed[0]["result"]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_batch_calls():
+    adapter = McpAdapter()
+    ctx = _RecordingContext(
+        agent_config={"mcp_servers": [_mcp_server_config()]},
+        input={
+            "calls": [
+                {"tool": "mcp/echo/ping", "arguments": {"message": "a"}},
+                {"tool": "mcp/echo/add", "arguments": {"a": 2, "b": 3}},
+            ]
+        },
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output["count"] == 2
+    assert result.output["calls"][1]["result"]["text"] == "5"
+
+    tool_events = [e for e, _ in ctx.events if e.startswith("tool_call.")]
+    assert len(tool_events) == 4
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_rejects_non_mcp_tool():
+    adapter = McpAdapter()
+    ctx = _RecordingContext(
+        agent_config={"mcp_servers": [_mcp_server_config()]},
+        input={"tool": "echo", "arguments": {"text": "hi"}},
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.FAILED
+    assert "mcp/" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_config_steps():
+    adapter = McpAdapter()
+    ctx = _RecordingContext(
+        agent_config={
+            "mcp_servers": [_mcp_server_config()],
+            "steps": [{"tool": "mcp/echo/ping", "arguments": {"message": "from-config"}}],
+        },
+        input={},
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output["result"]["text"] == "from-config"

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -130,6 +130,29 @@ async def test_langgraph_mcp_tool_writes_tool_call_events():
     assert tool_completed[0]["result"]["text"]
 
 
+@pytest.mark.asyncio
+async def test_mcp_call_tool_raises_on_error():
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.adapters.mcp_client import McpSessionManager, McpServerConfig
+    from mcp.types import CallToolResult, TextContent
+
+    manager = McpSessionManager(
+        [McpServerConfig(name="echo", transport="stdio", command="true")]
+    )
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=CallToolResult(
+            content=[TextContent(type="text", text="bad input")],
+            is_error=True,
+        )
+    )
+    manager._sessions["echo"] = session
+
+    with pytest.raises(RuntimeError, match="bad input"):
+        await manager.call_tool("echo", "ping", {"message": "x"})
+
+
 def test_serialize_call_tool_result_text():
     from mcp.types import CallToolResult, TextContent
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,6 +128,66 @@ toolsets. One PydanticAI run maps to one runtime step; token deltas, output,
 provider usage/cost, and tool events are translated to standard adapter events.
 The MVP does not rebuild Agents from JSON or implement checkpoint/resume.
 
+## MCP tool bridge
+
+MCP (Model Context Protocol) tools are wired through a shared bridge so every
+adapter persists the same `ToolCall` rows and SSE events:
+
+```
+agent.config.mcp_servers
+        │
+        ▼
+  McpSessionManager          stdio / SSE / Streamable HTTP
+        │
+        ▼
+  resolve_run_tools()        registry keys: mcp/{server}/{tool}
+        │
+        ▼
+  AdapterToolSurface         emit tool_call.started / tool_call.completed
+        │
+        ├── McpAdapter           direct tool invocation (no LLM)
+        └── LangGraphAdapter     tool / agent graph nodes
+```
+
+Configure servers in `agent.config.mcp_servers` and reference tools by key
+(`mcp/{server}/{tool}`) in `agent.config.tools`, or set
+`mcp_auto_register: true` to expose every tool from configured servers.
+
+**Built-in `mcp` adapter** — for runs that only call MCP tools:
+
+```jsonc
+{
+  "adapter": "mcp",
+  "config": {
+    "mcp_servers": [{
+      "name": "echo",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["path/to/mcp_server.py"]
+    }],
+    "steps": [
+      {"tool": "mcp/echo/ping", "arguments": {"message": "hello"}}
+    ]
+  }
+}
+```
+
+Alternatively pass a single call or batch in run `input`:
+
+```json
+{"tool": "mcp/echo/ping", "arguments": {"message": "hello"}}
+```
+
+```json
+{"calls": [
+  {"tool": "mcp/echo/ping", "arguments": {"message": "a"}},
+  {"tool": "mcp/echo/add", "arguments": {"a": 1, "b": 2}}
+]}
+```
+
+LangGraph graphs can invoke the same MCP tools via `type: "tool"` or
+`type: "agent"` nodes without a separate adapter.
+
 ## Unit tests
 
 The Python test suite in `backend/tests/` exercises adapter and queue logic

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -11,7 +11,7 @@
 1. ~~**事件总线持久化。**~~ 已用 Redis Stream `agentflow:run:{run_id}:log` 做 durable replay；pub/sub 仍负责 live 投递；支持 `Last-Event-ID` 重放。
 2. **队列 / LLM / Run OTel 指标与背压。** 深度/消费者延迟已导出为 `agentflow.queue.*`；worker 利用率见 `agentflow.worker.utilization`；LLM token/cost、Run 结局、Step/ToolCall RED 见 `agentflow.llm.*` / `agentflow.run.outcomes` / `agentflow.step.*` / `agentflow.tool.*`；面板见 `docker/grafana/dashboards/agentflow-observability.json`。
 3. **控制台调试体验。** Step 可视化时间线、独立 ToolCall 检查面板。
-4. **LangGraph adapter 扩展。** 更多 graph 模式、MCP 工具协议集成。
+4. ~~**LangGraph adapter 扩展。**~~ 更多 graph 模式、MCP 工具协议集成（`mcp` adapter + `AdapterToolSurface` bridge）。
 5. **双向流式传输。** WebSocket / WebTransport + SSE 降级，支持双向取消与审批。
 ## 可引入的先进技术
 
@@ -47,7 +47,7 @@
 
 - [x] Adapter 插件注册表（entry points / 动态加载）
 - [ ] 官方 adapter：AutoGen、CrewAI、PydanticAI（按需求选 2 个）
-- [ ] MCP tool adapter
+- [x] MCP tool adapter
 - [ ] OpenAPI 规范 + Python/TypeScript SDK 自动生成
 - [ ] Webhook 出站事件（`run.completed` 等）
 - [x] Agent 版本管理与配置 diff
@@ -90,7 +90,7 @@
 | --- | --- |
 | 事件重放 | `backend/app/events/bus.py`、`backend/app/api/v1/events.py` |
 | 修控制台 | `frontend/app/runs/`、`frontend/components/` |
-| 新 adapter | `backend/app/adapters/` + `__init__.py` 注册 |
+| 新 adapter | `backend/app/adapters/` + `__init__.py` 注册；MCP 见 [architecture.md](architecture.md#mcp-tool-bridge) |
 | 扩展 API | 先改 [api-contract.md](api-contract.md)，再实现 Java API；涉及执行协议时同步 Python Worker |
 | 队列可靠性 | `backend/app/worker/queue.py`、`backend/app/worker/monitor.py` |
 | 可观测性 | `backend/app/core/telemetry.py`、Java `RedMetricsFilter` |


### PR DESCRIPTION
feat: #47 
- Added `McpAdapter` to facilitate direct calls to MCP tools without an LLM orchestrator.
- Updated documentation to include MCP tool bridge details and configuration examples.
- Enhanced error handling in MCP client for better feedback on tool call failures.
- Added tests for MCP adapter functionality, including single and batch tool calls.
- Updated relevant README files to reflect the addition of MCP support.