### PR TITLE
feat: implement multi-tenant API key authentication

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/config/AgentflowProperties.java
+++ b/backend-java/src/main/java/io/agentflow/api/config/AgentflowProperties.java
@@ -12,6 +12,7 @@ public class AgentflowProperties {
     private Cancel cancel = new Cancel();
     private Events events = new Events();
     private Otel otel = new Otel();
+    private Auth auth = new Auth();
 
     public String getVersion() {
         return version;
@@ -59,6 +60,65 @@ public class AgentflowProperties {
 
     public void setOtel(Otel otel) {
         this.otel = otel;
+    }
+
+    public Auth getAuth() {
+        return auth;
+    }
+
+    public void setAuth(Auth auth) {
+        this.auth = auth;
+    }
+
+    public static class Auth {
+        private boolean enabled = false;
+        private List<ApiKeyEntry> keys = List.of();
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public List<ApiKeyEntry> getKeys() {
+            return keys;
+        }
+
+        public void setKeys(List<ApiKeyEntry> keys) {
+            this.keys = keys == null ? List.of() : keys;
+        }
+    }
+
+    public static class ApiKeyEntry {
+        private String key;
+        private String tenantId = "default";
+        private String role = "admin";
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getTenantId() {
+            return tenantId;
+        }
+
+        public void setTenantId(String tenantId) {
+            this.tenantId = tenantId;
+        }
+
+        public String getRole() {
+            return role;
+        }
+
+        public void setRole(String role) {
+            this.role = role;
+        }
     }
 
     public static class Otel {

--- a/backend-java/src/main/java/io/agentflow/api/controller/EventsController.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/EventsController.java
@@ -1,6 +1,7 @@
 package io.agentflow.api.controller;
 
 import io.agentflow.api.service.EventStreamService;
+import io.agentflow.api.service.RunService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,9 +17,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class EventsController {
 
     private final EventStreamService events;
+    private final RunService runs;
 
-    public EventsController(EventStreamService events) {
+    public EventsController(EventStreamService events, RunService runs) {
         this.events = events;
+        this.runs = runs;
     }
 
     @GetMapping(value = "/{runId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -26,6 +29,7 @@ public class EventsController {
             @PathVariable String runId,
             @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId,
             @RequestParam(value = "last_event_id", required = false) String lastEventIdParam) {
+        runs.requireAccessible(runId);
         String after =
                 lastEventId != null && !lastEventId.isBlank() ? lastEventId : lastEventIdParam;
         SseEmitter emitter = events.subscribe(runId, after);

--- a/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import io.agentflow.api.service.RegressionExecutionException;
 import io.agentflow.api.service.RunComparisonValidationException;
 import io.agentflow.api.service.RunConflictException;
 import io.agentflow.api.service.RunNotFoundException;
+import io.agentflow.api.security.ForbiddenException;
+import io.agentflow.api.security.UnauthorizedException;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -57,5 +59,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleRegressionExecution(
             RegressionExecutionException ex) {
         return ResponseEntity.status(ex.status()).body(Map.of("detail", ex.getMessage()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<Map<String, String>> handleUnauthorized(UnauthorizedException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .header("WWW-Authenticate", "Bearer")
+                .body(Map.of("detail", ex.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<Map<String, String>> handleForbidden(ForbiddenException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("detail", ex.getMessage()));
     }
 }

--- a/backend-java/src/main/java/io/agentflow/api/dto/AgentResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/AgentResponse.java
@@ -7,6 +7,7 @@ import java.util.Map;
 public class AgentResponse {
 
     private String id;
+    private String tenantId;
     private String name;
     private String description;
     private String adapter;
@@ -18,6 +19,7 @@ public class AgentResponse {
     public static AgentResponse fromEntity(AgentEntity entity) {
         AgentResponse dto = new AgentResponse();
         dto.id = entity.getId();
+        dto.tenantId = entity.getTenantId();
         dto.name = entity.getName();
         dto.description = entity.getDescription();
         dto.adapter = entity.getAdapter();
@@ -30,6 +32,10 @@ public class AgentResponse {
 
     public String getId() {
         return id;
+    }
+
+    public String getTenantId() {
+        return tenantId;
     }
 
     public String getName() {

--- a/backend-java/src/main/java/io/agentflow/api/dto/RunResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunResponse.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public class RunResponse {
 
     private String id;
+    private String tenantId;
     private String agentId;
     private String adapter;
     private RunStatus status;
@@ -51,6 +52,7 @@ public class RunResponse {
             RunUsage usage) {
         RunResponse dto = new RunResponse();
         dto.id = entity.getId();
+        dto.tenantId = entity.getTenantId();
         dto.agentId = entity.getAgentId();
         dto.adapter = entity.getAdapter();
         dto.status = entity.getStatus();
@@ -68,6 +70,10 @@ public class RunResponse {
 
     public String getId() {
         return id;
+    }
+
+    public String getTenantId() {
+        return tenantId;
     }
 
     public String getAgentId() {

--- a/backend-java/src/main/java/io/agentflow/api/entity/AgentEntity.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/AgentEntity.java
@@ -8,19 +8,28 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
 @Entity
-@Table(name = "agents")
+@Table(
+        name = "agents",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uq_agents_tenant_name",
+                        columnNames = {"tenant_id", "name"}))
 public class AgentEntity {
 
     @Id
     @Column(length = 26)
     private String id;
 
-    @Column(nullable = false, unique = true, length = 128)
+    @Column(name = "tenant_id", nullable = false, length = 64)
+    private String tenantId = "default";
+
+    @Column(nullable = false, length = 128)
     private String name;
 
     @Column(length = 1024)
@@ -65,6 +74,14 @@ public class AgentEntity {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public String getName() {

--- a/backend-java/src/main/java/io/agentflow/api/entity/RunEntity.java
+++ b/backend-java/src/main/java/io/agentflow/api/entity/RunEntity.java
@@ -22,6 +22,9 @@ public class RunEntity {
     @Column(length = 26)
     private String id;
 
+    @Column(name = "tenant_id", nullable = false, length = 64)
+    private String tenantId = "default";
+
     @Column(name = "agent_id", nullable = false, length = 26)
     private String agentId;
 
@@ -80,6 +83,14 @@ public class RunEntity {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public String getAgentId() {

--- a/backend-java/src/main/java/io/agentflow/api/repository/AgentRepository.java
+++ b/backend-java/src/main/java/io/agentflow/api/repository/AgentRepository.java
@@ -2,11 +2,14 @@ package io.agentflow.api.repository;
 
 import io.agentflow.api.entity.AgentEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AgentRepository extends JpaRepository<AgentEntity, String> {
 
-    List<AgentEntity> findAllByOrderByCreatedAtDesc();
+    List<AgentEntity> findAllByTenantIdOrderByCreatedAtDesc(String tenantId);
 
-    boolean existsByName(String name);
+    boolean existsByTenantIdAndName(String tenantId, String name);
+
+    Optional<AgentEntity> findByIdAndTenantId(String id, String tenantId);
 }

--- a/backend-java/src/main/java/io/agentflow/api/repository/RunRepository.java
+++ b/backend-java/src/main/java/io/agentflow/api/repository/RunRepository.java
@@ -2,12 +2,18 @@ package io.agentflow.api.repository;
 
 import io.agentflow.api.entity.RunEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RunRepository extends JpaRepository<RunEntity, String> {
 
-    @Query("SELECT r FROM RunEntity r ORDER BY r.createdAt DESC")
-    List<RunEntity> findRecent(Pageable pageable);
+    @Query(
+            "SELECT r FROM RunEntity r WHERE r.tenantId = :tenantId ORDER BY r.createdAt DESC")
+    List<RunEntity> findRecentByTenantId(
+            @Param("tenantId") String tenantId, Pageable pageable);
+
+    Optional<RunEntity> findByIdAndTenantId(String id, String tenantId);
 }

--- a/backend-java/src/main/java/io/agentflow/api/security/AccessControl.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/AccessControl.java
@@ -1,0 +1,19 @@
+package io.agentflow.api.security;
+
+public final class AccessControl {
+
+    private AccessControl() {}
+
+    public static AuthPrincipal require(Role minimum) {
+        AuthPrincipal principal = TenantContext.require();
+        if (!principal.role().atLeast(minimum)) {
+            throw new ForbiddenException(
+                    "Requires role " + minimum.name().toLowerCase() + " or higher");
+        }
+        return principal;
+    }
+
+    public static String tenantId(Role minimum) {
+        return require(minimum).tenantId();
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/security/AuthFilter.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/AuthFilter.java
@@ -1,0 +1,129 @@
+package io.agentflow.api.security;
+
+import io.agentflow.api.config.AgentflowProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Resolves the caller's tenant + role from an API key.
+ *
+ * <p>When {@code agentflow.auth.enabled=false} (default), every request is
+ * treated as {@code admin} on the {@code default} tenant so local development
+ * stays unchanged.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 20)
+public class AuthFilter extends OncePerRequestFilter {
+
+    private final AgentflowProperties properties;
+
+    public AuthFilter(AgentflowProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.equals("/")
+                || path.equals("/v1/health")
+                || path.startsWith("/actuator");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            AuthPrincipal principal = resolve(request);
+            if (principal == null) {
+                writeError(response, HttpStatus.UNAUTHORIZED, "Missing or invalid API key");
+                return;
+            }
+            TenantContext.set(principal);
+            filterChain.doFilter(request, response);
+        } finally {
+            TenantContext.clear();
+        }
+    }
+
+    private AuthPrincipal resolve(HttpServletRequest request) {
+        AgentflowProperties.Auth auth = properties.getAuth();
+        if (!auth.isEnabled()) {
+            return new AuthPrincipal(
+                    TenantContext.DEFAULT_TENANT_ID, Role.ADMIN, "anonymous");
+        }
+        String token = extractToken(request);
+        if (token == null) {
+            return null;
+        }
+        return indexKeys(auth.getKeys()).get(token);
+    }
+
+    private static String extractToken(HttpServletRequest request) {
+        String apiKey = request.getHeader("X-Api-Key");
+        if (apiKey != null && !apiKey.isBlank()) {
+            return apiKey.trim();
+        }
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null || authorization.isBlank()) {
+            return null;
+        }
+        String[] parts = authorization.trim().split("\\s+", 2);
+        if (parts.length == 2 && "bearer".equalsIgnoreCase(parts[0])) {
+            return parts[1].trim();
+        }
+        return null;
+    }
+
+    private static Map<String, AuthPrincipal> indexKeys(
+            List<AgentflowProperties.ApiKeyEntry> entries) {
+        Map<String, AuthPrincipal> map = new LinkedHashMap<>();
+        if (entries == null) {
+            return map;
+        }
+        for (AgentflowProperties.ApiKeyEntry entry : entries) {
+            if (entry.getKey() == null || entry.getKey().isBlank()) {
+                continue;
+            }
+            String tenant =
+                    entry.getTenantId() == null || entry.getTenantId().isBlank()
+                            ? TenantContext.DEFAULT_TENANT_ID
+                            : entry.getTenantId().trim();
+            Role role =
+                    entry.getRole() == null || entry.getRole().isBlank()
+                            ? Role.VIEWER
+                            : Role.parse(entry.getRole());
+            String token = entry.getKey().trim();
+            map.put(
+                    token,
+                    new AuthPrincipal(tenant, role, token.substring(0, Math.min(8, token.length()))));
+        }
+        return map;
+    }
+
+    private static void writeError(HttpServletResponse response, HttpStatus status, String detail)
+            throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        if (status == HttpStatus.UNAUTHORIZED) {
+            response.setHeader("WWW-Authenticate", "Bearer");
+        }
+        String body =
+                "{\"detail\":\""
+                        + detail.replace("\\", "\\\\").replace("\"", "\\\"")
+                        + "\"}";
+        response.getWriter().write(body);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/security/AuthPrincipal.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/AuthPrincipal.java
@@ -1,0 +1,3 @@
+package io.agentflow.api.security;
+
+public record AuthPrincipal(String tenantId, Role role, String subject) {}

--- a/backend-java/src/main/java/io/agentflow/api/security/ForbiddenException.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/ForbiddenException.java
@@ -1,0 +1,8 @@
+package io.agentflow.api.security;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/security/Role.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/Role.java
@@ -1,0 +1,24 @@
+package io.agentflow.api.security;
+
+/**
+ * Coarse RBAC roles. Higher ordinals include lower privileges.
+ *
+ * <ul>
+ *   <li>{@link #VIEWER} — list/get agents, runs, SSE</li>
+ *   <li>{@link #OPERATOR} — create/cancel/retry/resume runs</li>
+ *   <li>{@link #ADMIN} — create/update/restore agents</li>
+ * </ul>
+ */
+public enum Role {
+    VIEWER,
+    OPERATOR,
+    ADMIN;
+
+    public boolean atLeast(Role required) {
+        return this.ordinal() >= required.ordinal();
+    }
+
+    public static Role parse(String raw) {
+        return Role.valueOf(raw.trim().toUpperCase());
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/security/TenantContext.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/TenantContext.java
@@ -1,0 +1,35 @@
+package io.agentflow.api.security;
+
+/** Request-scoped auth identity. Cleared by {@link AuthFilter} after each request. */
+public final class TenantContext {
+
+    public static final String DEFAULT_TENANT_ID = "default";
+
+    private static final ThreadLocal<AuthPrincipal> CURRENT = new ThreadLocal<>();
+
+    private TenantContext() {}
+
+    public static void set(AuthPrincipal principal) {
+        CURRENT.set(principal);
+    }
+
+    public static AuthPrincipal get() {
+        return CURRENT.get();
+    }
+
+    public static AuthPrincipal require() {
+        AuthPrincipal principal = CURRENT.get();
+        if (principal == null) {
+            throw new UnauthorizedException("Authentication required");
+        }
+        return principal;
+    }
+
+    public static String tenantId() {
+        return require().tenantId();
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/security/UnauthorizedException.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package io.agentflow.api.security;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/AgentService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/AgentService.java
@@ -9,6 +9,8 @@ import io.agentflow.api.entity.AgentEntity;
 import io.agentflow.api.entity.AgentVersionEntity;
 import io.agentflow.api.repository.AgentRepository;
 import io.agentflow.api.repository.AgentVersionRepository;
+import io.agentflow.api.security.AccessControl;
+import io.agentflow.api.security.Role;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,10 +34,12 @@ public class AgentService {
 
     @Transactional
     public AgentResponse create(AgentCreateRequest req) {
-        if (repository.existsByName(req.getName())) {
+        String tenantId = AccessControl.tenantId(Role.ADMIN);
+        if (repository.existsByTenantIdAndName(tenantId, req.getName())) {
             throw new AgentNameConflictException(req.getName());
         }
         AgentEntity entity = new AgentEntity();
+        entity.setTenantId(tenantId);
         entity.setName(req.getName());
         entity.setDescription(req.getDescription());
         entity.setAdapter(req.getAdapter());
@@ -52,25 +56,28 @@ public class AgentService {
 
     @Transactional(readOnly = true)
     public List<AgentResponse> list() {
-        return repository.findAllByOrderByCreatedAtDesc().stream()
+        String tenantId = AccessControl.tenantId(Role.VIEWER);
+        return repository.findAllByTenantIdOrderByCreatedAtDesc(tenantId).stream()
                 .map(AgentResponse::fromEntity)
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public AgentResponse get(String id) {
-        return repository.findById(id)
-                .map(AgentResponse::fromEntity)
-                .orElseThrow(() -> new AgentNotFoundException(id));
+        return AgentResponse.fromEntity(getEntity(id));
     }
 
     @Transactional(readOnly = true)
     public AgentEntity getEntity(String id) {
-        return repository.findById(id).orElseThrow(() -> new AgentNotFoundException(id));
+        String tenantId = AccessControl.tenantId(Role.VIEWER);
+        return repository
+                .findByIdAndTenantId(id, tenantId)
+                .orElseThrow(() -> new AgentNotFoundException(id));
     }
 
     @Transactional
     public AgentResponse update(String id, AgentUpdateRequest req) {
+        AccessControl.require(Role.ADMIN);
         AgentEntity agent = getEntity(id);
 
         if (req.isNameSet() && req.getName() != null) {
@@ -164,6 +171,7 @@ public class AgentService {
 
     @Transactional
     public AgentResponse restore(String agentId, int version) {
+        AccessControl.require(Role.ADMIN);
         AgentEntity agent = getEntity(agentId);
         AgentVersionEntity snap =
                 versionRepository

--- a/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RegressionExecutionService.java
@@ -15,6 +15,8 @@ import io.agentflow.api.entity.RunEntity;
 import io.agentflow.api.entity.RunStatus;
 import io.agentflow.api.repository.AgentVersionRepository;
 import io.agentflow.api.repository.RunRepository;
+import io.agentflow.api.security.AccessControl;
+import io.agentflow.api.security.Role;
 import io.agentflow.api.service.RegressionExecutionManifest.CaseReference;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,16 +54,12 @@ public class RegressionExecutionService {
     }
 
     public RegressionExecutionResponse create(RegressionExecutionCreateRequest request) {
+        AccessControl.require(Role.OPERATOR);
+        String tenantId = AccessControl.tenantId(Role.OPERATOR);
         List<String> baselineIds = normalizeIds(request);
-        Map<String, RunEntity> loaded = byId(runs.findAllById(baselineIds));
         List<RunEntity> baselines = baselineIds.stream()
-                .map(id -> {
-                    RunEntity run = loaded.get(id);
-                    if (run == null) {
-                        throw new RunNotFoundException(id);
-                    }
-                    return run;
-                })
+                .map(id -> runs.findByIdAndTenantId(id, tenantId)
+                        .orElseThrow(() -> new RunNotFoundException(id)))
                 .toList();
         validateBaselines(baselines);
 
@@ -148,14 +146,15 @@ public class RegressionExecutionService {
     }
 
     private Map<String, RunEntity> candidateRuns(RegressionExecutionManifest manifest) {
+        String tenantId = AccessControl.tenantId(Role.VIEWER);
         List<String> ids = manifest.cases().stream()
                 .map(CaseReference::candidateRunId)
                 .toList();
-        Map<String, RunEntity> result = byId(runs.findAllById(ids));
+        Map<String, RunEntity> result = new HashMap<>();
         for (String id : ids) {
-            if (!result.containsKey(id)) {
-                throw new RunNotFoundException(id);
-            }
+            RunEntity run = runs.findByIdAndTenantId(id, tenantId)
+                    .orElseThrow(() -> new RunNotFoundException(id));
+            result.put(id, run);
         }
         return result;
     }

--- a/backend-java/src/main/java/io/agentflow/api/service/RunComparisonService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunComparisonService.java
@@ -6,6 +6,8 @@ import io.agentflow.api.dto.RunComparisonResponse.RunSide;
 import io.agentflow.api.entity.RunEntity;
 import io.agentflow.api.entity.RunStatus;
 import io.agentflow.api.repository.RunRepository;
+import io.agentflow.api.security.AccessControl;
+import io.agentflow.api.security.Role;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +27,7 @@ public class RunComparisonService {
 
     @Transactional(readOnly = true)
     public RunComparisonResponse preview(RunComparisonPreviewRequest request) {
+        String tenantId = AccessControl.tenantId(Role.VIEWER);
         String baselineId = normalizedId(
                 request == null ? null : request.baselineRunId(), "baseline_run_id");
         String candidateId = normalizedId(
@@ -34,9 +37,9 @@ public class RunComparisonService {
                     "Baseline and candidate run IDs must differ.");
         }
 
-        RunEntity baseline = runs.findById(baselineId)
+        RunEntity baseline = runs.findByIdAndTenantId(baselineId, tenantId)
                 .orElseThrow(() -> new RunNotFoundException(baselineId));
-        RunEntity candidate = runs.findById(candidateId)
+        RunEntity candidate = runs.findByIdAndTenantId(candidateId, tenantId)
                 .orElseThrow(() -> new RunNotFoundException(candidateId));
         if (!Objects.equals(baseline.getAgentId(), candidate.getAgentId())) {
             throw new RunComparisonValidationException(

--- a/backend-java/src/main/java/io/agentflow/api/service/RunService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunService.java
@@ -21,6 +21,8 @@ import io.agentflow.api.repository.MessageRepository;
 import io.agentflow.api.repository.RunRepository;
 import io.agentflow.api.repository.StepRepository;
 import io.agentflow.api.repository.ToolCallRepository;
+import io.agentflow.api.security.AccessControl;
+import io.agentflow.api.security.Role;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -74,12 +76,14 @@ public class RunService {
 
     @Transactional
     public RunResponse create(RunCreateRequest req) {
+        AccessControl.require(Role.OPERATOR);
         AgentEntity agent = agentService.getEntity(req.getAgentId());
         String adapter = (req.getAdapter() != null && !req.getAdapter().isBlank())
                 ? req.getAdapter()
                 : agent.getAdapter();
 
         RunEntity run = new RunEntity();
+        run.setTenantId(agent.getTenantId());
         run.setAgentId(agent.getId());
         run.setAdapter(adapter);
         run.setStatus(RunStatus.PENDING);
@@ -102,9 +106,12 @@ public class RunService {
             String adapter,
             int agentVersion,
             List<Map<String, Object>> inputs) {
+        AccessControl.require(Role.OPERATOR);
+        AgentEntity agent = agentService.getEntity(agentId);
         List<RunEntity> candidates = new ArrayList<>(inputs.size());
         for (Map<String, Object> input : inputs) {
             RunEntity run = new RunEntity();
+            run.setTenantId(agent.getTenantId());
             run.setAgentId(agentId);
             run.setAdapter(adapter);
             run.setStatus(RunStatus.PENDING);
@@ -125,22 +132,28 @@ public class RunService {
 
     @Transactional(readOnly = true)
     public List<RunResponse> list(int limit) {
+        String tenantId = AccessControl.tenantId(Role.VIEWER);
         int capped = Math.max(1, Math.min(limit, 200));
         // Header rows only — matches Python list_runs (no steps/messages/checkpoints).
-        return runs.findRecent(PageRequest.of(0, capped)).stream()
+        return runs.findRecentByTenantId(tenantId, PageRequest.of(0, capped)).stream()
                 .map(RunResponse::fromEntity)
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public RunResponse get(String id) {
-        RunEntity run = runs.findById(id).orElseThrow(() -> new RunNotFoundException(id));
-        return toResponse(run);
+        return toResponse(requireRun(id, Role.VIEWER));
+    }
+
+    /** Ensure the run exists in the caller's tenant (for SSE and cross-service checks). */
+    @Transactional(readOnly = true)
+    public void requireAccessible(String id) {
+        requireRun(id, Role.VIEWER);
     }
 
     @Transactional
     public void cancel(String id) {
-        RunEntity run = runs.findById(id).orElseThrow(() -> new RunNotFoundException(id));
+        RunEntity run = requireRun(id, Role.OPERATOR);
         cancelSignal.requestCancel(run.getId());
         // We do not flip the row to CANCELLED here: the worker owns the
         // transition so steps/messages can be flushed first.
@@ -148,7 +161,7 @@ public class RunService {
 
     @Transactional
     public RunResponse retry(String id, RunRetryRequest req) {
-        RunEntity run = runs.findById(id).orElseThrow(() -> new RunNotFoundException(id));
+        RunEntity run = requireRun(id, Role.OPERATOR);
         if (run.getStatus() != RunStatus.FAILED) {
             throw new RunConflictException(
                     "Cannot retry run " + id + " in status " + run.getStatus().wire());
@@ -186,7 +199,7 @@ public class RunService {
 
     @Transactional
     public RunResponse resume(String id, RunResumeRequest req) {
-        RunEntity run = runs.findById(id).orElseThrow(() -> new RunNotFoundException(id));
+        RunEntity run = requireRun(id, Role.OPERATOR);
         if (run.getStatus() != RunStatus.WAITING_HUMAN) {
             throw new RunConflictException(
                     "Cannot resume run " + id + " in status " + run.getStatus().wire());
@@ -217,6 +230,12 @@ public class RunService {
         RunEntity saved = runs.save(run);
         enqueueJobAfterCommit(saved.getId(), saved.getAgentId(), saved.getAdapter());
         return toResponse(saved);
+    }
+
+    private RunEntity requireRun(String id, Role minimum) {
+        String tenantId = AccessControl.tenantId(minimum);
+        return runs.findByIdAndTenantId(id, tenantId)
+                .orElseThrow(() -> new RunNotFoundException(id));
     }
 
     /**

--- a/backend-java/src/main/resources/application.yml
+++ b/backend-java/src/main/resources/application.yml
@@ -42,6 +42,14 @@ agentflow:
   otel:
     enabled: ${AGENTFLOW_OTEL_ENABLED:false}
     service-name: ${AGENTFLOW_OTEL_SERVICE_NAME:agentflow-api}
+  auth:
+    # Off by default for local/dev. Set AGENTFLOW_AUTH_ENABLED=true and
+    # configure keys to enforce tenant isolation + RBAC.
+    enabled: ${AGENTFLOW_AUTH_ENABLED:false}
+    keys:
+      - key: ${AGENTFLOW_API_KEY_ADMIN:dev-admin}
+        tenant-id: default
+        role: admin
 
 management:
   tracing:

--- a/backend-java/src/test/java/io/agentflow/api/security/AccessControlTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/security/AccessControlTest.java
@@ -1,0 +1,34 @@
+package io.agentflow.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class AccessControlTest {
+
+    @AfterEach
+    void clear() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void adminSatisfiesViewer() {
+        TenantContext.set(new AuthPrincipal("t1", Role.ADMIN, "x"));
+        assertThat(AccessControl.tenantId(Role.VIEWER)).isEqualTo("t1");
+    }
+
+    @Test
+    void viewerDeniedAdmin() {
+        TenantContext.set(new AuthPrincipal("t1", Role.VIEWER, "x"));
+        assertThatThrownBy(() -> AccessControl.require(Role.ADMIN))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void missingPrincipalIsUnauthorized() {
+        assertThatThrownBy(() -> AccessControl.require(Role.VIEWER))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+}

--- a/backend-java/src/test/java/io/agentflow/api/security/AuthTenantWebTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/security/AuthTenantWebTest.java
@@ -1,0 +1,100 @@
+package io.agentflow.api.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.agentflow.api.config.AgentflowProperties;
+import io.agentflow.api.config.JacksonConfig;
+import io.agentflow.api.config.PropertiesConfig;
+import io.agentflow.api.controller.AgentsController;
+import io.agentflow.api.controller.GlobalExceptionHandler;
+import io.agentflow.api.controller.HealthController;
+import io.agentflow.api.dto.AgentResponse;
+import io.agentflow.api.entity.AgentEntity;
+import io.agentflow.api.service.AgentService;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {AgentsController.class, HealthController.class})
+@Import({
+    JacksonConfig.class,
+    PropertiesConfig.class,
+    AgentflowProperties.class,
+    AuthFilter.class,
+    GlobalExceptionHandler.class
+})
+@TestPropertySource(
+        properties = {
+            "agentflow.version=0.1.0",
+            "agentflow.adapters=echo",
+            "agentflow.auth.enabled=true",
+            "agentflow.auth.keys[0].key=admin-a",
+            "agentflow.auth.keys[0].tenant-id=tenant-a",
+            "agentflow.auth.keys[0].role=admin",
+            "agentflow.auth.keys[1].key=viewer-a",
+            "agentflow.auth.keys[1].tenant-id=tenant-a",
+            "agentflow.auth.keys[1].role=viewer",
+        })
+class AuthTenantWebTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    AgentService agentService;
+
+    @Test
+    void healthRemainsOpen() throws Exception {
+        mvc.perform(get("/v1/health")).andExpect(status().isOk());
+    }
+
+    @Test
+    void missingKeyIsUnauthorized() throws Exception {
+        mvc.perform(get("/v1/agents")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void adminCanCreateAgent() throws Exception {
+        AgentResponse dto = newAgent("id1", "tenant-a", "writer");
+        Mockito.when(agentService.create(Mockito.any())).thenReturn(dto);
+
+        mvc.perform(
+                        post("/v1/agents")
+                                .header("X-Api-Key", "admin-a")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"name\":\"writer\",\"adapter\":\"echo\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tenant_id").value("tenant-a"))
+                .andExpect(jsonPath("$.name").value("writer"));
+    }
+
+    @Test
+    void invalidKeyIsUnauthorized() throws Exception {
+        mvc.perform(get("/v1/agents").header("Authorization", "Bearer nope"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private static AgentResponse newAgent(String id, String tenantId, String name) {
+        AgentEntity entity = new AgentEntity();
+        entity.setId(id);
+        entity.setTenantId(tenantId);
+        entity.setName(name);
+        entity.setAdapter("echo");
+        entity.setConfig(Map.of());
+        entity.setVersion(1);
+        entity.setCreatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+        entity.setUpdatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+        return AgentResponse.fromEntity(entity);
+    }
+}

--- a/backend-java/src/test/java/io/agentflow/api/service/RunComparisonServiceTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/service/RunComparisonServiceTest.java
@@ -8,19 +8,34 @@ import io.agentflow.api.dto.RunComparisonPreviewRequest;
 import io.agentflow.api.entity.RunEntity;
 import io.agentflow.api.entity.RunStatus;
 import io.agentflow.api.repository.RunRepository;
+import io.agentflow.api.security.AuthPrincipal;
+import io.agentflow.api.security.Role;
+import io.agentflow.api.security.TenantContext;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class RunComparisonServiceTest {
+
+    @BeforeEach
+    void setPrincipal() {
+        TenantContext.set(new AuthPrincipal("default", Role.ADMIN, "test"));
+    }
+
+    @AfterEach
+    void clearPrincipal() {
+        TenantContext.clear();
+    }
 
     @Test
     void comparesSimpleRunSummary() {
         RunRepository runs = mock(RunRepository.class);
         RunEntity baseline = run("baseline", 1, Map.of("answer", "old"));
         RunEntity candidate = run("candidate", 2, Map.of("answer", "new"));
-        when(runs.findById("baseline")).thenReturn(Optional.of(baseline));
-        when(runs.findById("candidate")).thenReturn(Optional.of(candidate));
+        when(runs.findByIdAndTenantId("baseline", "default")).thenReturn(Optional.of(baseline));
+        when(runs.findByIdAndTenantId("candidate", "default")).thenReturn(Optional.of(candidate));
 
         var result = new RunComparisonService(runs)
                 .preview(new RunComparisonPreviewRequest("baseline", "candidate"));

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,3 +23,9 @@ AGENTFLOW_JOB_QUEUE_CONSUMER_DELAY_ALERT_SECONDS=300
 AGENTFLOW_JOB_QUEUE_DEPTH_ALERT_THRESHOLD=100
 AGENTFLOW_WORKER_JOB_P95_ALERT_SECONDS=60
 AGENTFLOW_WORKER_JOB_P95_ALERT_MIN_SAMPLES=10
+
+# Multi-tenant API key auth (off by default). When enabled, /v1/* (except
+# health) requires Authorization: Bearer <key> or X-Api-Key.
+# Keys are comma-separated key:tenant_id:role (viewer|operator|admin).
+AGENTFLOW_AUTH_ENABLED=false
+AGENTFLOW_AUTH_API_KEYS=dev-admin:default:admin

--- a/backend/alembic/versions/0004_tenant_id.py
+++ b/backend/alembic/versions/0004_tenant_id.py
@@ -1,0 +1,75 @@
+"""Add tenant_id to agents and runs for multi-tenant isolation.
+
+Revision ID: 0004_tenant_id
+Revises: 0003_agent_versions
+Create Date: 2026-08-21
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0004_tenant_id"
+down_revision = "0003_agent_versions"
+branch_labels = None
+depends_on = None
+
+_DEFAULT = "default"
+
+
+def _drop_agents_name_unique() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for uc in inspector.get_unique_constraints("agents"):
+        cols = list(uc.get("column_names") or [])
+        if cols == ["name"]:
+            op.drop_constraint(uc["name"], "agents", type_="unique")
+            return
+    # Fallback for dialects that only expose the unique as an index.
+    for ix in inspector.get_indexes("agents"):
+        if ix.get("unique") and list(ix.get("column_names") or []) == ["name"]:
+            op.drop_index(ix["name"], table_name="agents")
+            return
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column(
+            "tenant_id",
+            sa.String(64),
+            nullable=False,
+            server_default=_DEFAULT,
+        ),
+    )
+    op.add_column(
+        "runs",
+        sa.Column(
+            "tenant_id",
+            sa.String(64),
+            nullable=False,
+            server_default=_DEFAULT,
+        ),
+    )
+
+    _drop_agents_name_unique()
+    op.create_unique_constraint(
+        "uq_agents_tenant_name", "agents", ["tenant_id", "name"]
+    )
+
+    op.create_index("ix_agents_tenant_id", "agents", ["tenant_id"])
+    op.create_index("ix_runs_tenant_id", "runs", ["tenant_id"])
+    op.create_index(
+        "ix_runs_tenant_created", "runs", ["tenant_id", "created_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_runs_tenant_created", table_name="runs")
+    op.drop_index("ix_runs_tenant_id", table_name="runs")
+    op.drop_index("ix_agents_tenant_id", table_name="agents")
+    op.drop_constraint("uq_agents_tenant_name", "agents", type_="unique")
+    op.create_unique_constraint("agents_name_key", "agents", ["name"])
+    op.drop_column("runs", "tenant_id")
+    op.drop_column("agents", "tenant_id")

--- a/backend/app/api/v1/agents.py
+++ b/backend/app/api/v1/agents.py
@@ -3,6 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import AuthPrincipal, Role, require_role
 from app.db.session import get_session
 from app.models import Agent
 from app.models.agent import AgentVersion
@@ -24,11 +25,23 @@ from app.services.agent_versions import (
 router = APIRouter(prefix="/agents", tags=["agents"])
 
 
+async def _load_agent(
+    session: AsyncSession, agent_id: str, tenant_id: str
+) -> Agent:
+    agent = await session.get(Agent, agent_id)
+    if agent is None or agent.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
 @router.post("", response_model=AgentRead, status_code=status.HTTP_201_CREATED)
 async def create_agent(
-    payload: AgentCreate, session: AsyncSession = Depends(get_session)
+    payload: AgentCreate,
+    session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.ADMIN)),
 ) -> Agent:
     agent = Agent(
+        tenant_id=principal.tenant_id,
         name=payload.name,
         description=payload.description,
         adapter=payload.adapter,
@@ -51,19 +64,25 @@ async def create_agent(
 
 
 @router.get("", response_model=list[AgentRead])
-async def list_agents(session: AsyncSession = Depends(get_session)) -> list[Agent]:
-    result = await session.execute(select(Agent).order_by(Agent.created_at.desc()))
+async def list_agents(
+    session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
+) -> list[Agent]:
+    result = await session.execute(
+        select(Agent)
+        .where(Agent.tenant_id == principal.tenant_id)
+        .order_by(Agent.created_at.desc())
+    )
     return list(result.scalars())
 
 
 @router.get("/{agent_id}", response_model=AgentRead)
 async def get_agent(
-    agent_id: str, session: AsyncSession = Depends(get_session)
+    agent_id: str,
+    session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> Agent:
-    agent = await session.get(Agent, agent_id)
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    return agent
+    return await _load_agent(session, agent_id, principal.tenant_id)
 
 
 @router.patch("/{agent_id}", response_model=AgentRead)
@@ -71,10 +90,9 @@ async def update_agent(
     agent_id: str,
     payload: AgentUpdate,
     session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.ADMIN)),
 ) -> Agent:
-    agent = await session.get(Agent, agent_id)
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    agent = await _load_agent(session, agent_id, principal.tenant_id)
 
     fields_set = payload.model_fields_set
     if "name" in fields_set and payload.name is not None:
@@ -124,11 +142,11 @@ async def update_agent(
 
 @router.get("/{agent_id}/versions", response_model=list[AgentVersionRead])
 async def list_versions(
-    agent_id: str, session: AsyncSession = Depends(get_session)
+    agent_id: str,
+    session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> list[AgentVersion]:
-    agent = await session.get(Agent, agent_id)
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    await _load_agent(session, agent_id, principal.tenant_id)
     return await list_agent_versions(session, agent_id)
 
 
@@ -141,10 +159,9 @@ async def diff_versions(
     from_version: int = Query(..., alias="from", ge=1),
     to_version: int = Query(..., alias="to", ge=1),
     session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> AgentVersionDiff:
-    agent = await session.get(Agent, agent_id)
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    await _load_agent(session, agent_id, principal.tenant_id)
     left = await get_agent_version(session, agent_id, from_version)
     right = await get_agent_version(session, agent_id, to_version)
     if left is None or right is None:
@@ -163,10 +180,9 @@ async def get_version(
     agent_id: str,
     version: int,
     session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> AgentVersion:
-    agent = await session.get(Agent, agent_id)
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    await _load_agent(session, agent_id, principal.tenant_id)
     row = await get_agent_version(session, agent_id, version)
     if row is None:
         raise HTTPException(status_code=404, detail="Agent version not found")
@@ -181,11 +197,10 @@ async def restore_version(
     agent_id: str,
     version: int,
     session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.ADMIN)),
 ) -> Agent:
     """Restore adapter/config/description from a snapshot as a new version."""
-    agent = await session.get(Agent, agent_id)
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    agent = await _load_agent(session, agent_id, principal.tenant_id)
     snap = await get_agent_version(session, agent_id, version)
     if snap is None:
         raise HTTPException(status_code=404, detail="Agent version not found")
@@ -201,9 +216,7 @@ async def restore_version(
     agent.config = dict(snap.config or {})
     agent.description = snap.description
     agent.version = int(agent.version or 1) + 1
-    session.add(
-        snapshot_agent(agent, note=f"restored from v{version}")
-    )
+    session.add(snapshot_agent(agent, note=f"restored from v{version}"))
     await session.commit()
     await session.refresh(agent)
     return agent

--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -84,15 +84,19 @@ async def stream_run_events(
     session: AsyncSession = Depends(get_session),
     principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> EventSourceResponse:
+    settings = get_settings()
     run = await session.get(Run, run_id)
-    # Missing rows are allowed so clients can subscribe before the run is
-    # visible (and so event-bus unit tests can use synthetic ids). When the
-    # row exists it must belong to the caller's tenant.
+    # When auth is enabled, require the run to exist to avoid pre-subscribing to
+    # another tenant's run_id before it becomes visible.
+    if settings.auth_enabled and run is None:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+    # Missing rows are allowed (when auth is disabled) so clients can subscribe
+    # before the run is visible (and so event-bus unit tests can use synthetic ids).
     if run is not None and run.tenant_id != principal.tenant_id:
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
 
     after_id = _resolve_last_event_id(request)
-    heartbeat = float(get_settings().event_sse_heartbeat_seconds)
+    heartbeat = float(settings.event_sse_heartbeat_seconds)
 
     async def generator() -> AsyncIterator[dict[str, str]]:
         yield {"retry": _SSE_RETRY_MS}

--- a/backend/app/api/v1/events.py
+++ b/backend/app/api/v1/events.py
@@ -14,12 +14,16 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
+from app.core.auth import AuthPrincipal, Role, require_role
 from app.core.config import get_settings
+from app.db.session import get_session
 from app.events import EventBus, get_event_bus
 from app.events.bus import is_after
+from app.models import Run
 from app.schemas.run import RunEvent
 
 router = APIRouter(prefix="/events", tags=["events"])
@@ -77,7 +81,16 @@ async def stream_run_events(
     run_id: str,
     request: Request,
     bus: EventBus = Depends(get_event_bus),
+    session: AsyncSession = Depends(get_session),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> EventSourceResponse:
+    run = await session.get(Run, run_id)
+    # Missing rows are allowed so clients can subscribe before the run is
+    # visible (and so event-bus unit tests can use synthetic ids). When the
+    # row exists it must belong to the caller's tenant.
+    if run is not None and run.tenant_id != principal.tenant_id:
+        raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+
     after_id = _resolve_last_event_id(request)
     heartbeat = float(get_settings().event_sse_heartbeat_seconds)
 

--- a/backend/app/api/v1/runs.py
+++ b/backend/app/api/v1/runs.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import AuthPrincipal, Role, require_role
 from app.db.session import get_session
 from app.events import EventBus, get_event_bus
 from app.schemas.run import RunCreate, RunRead, RunResume, RunRetry, run_read_from_orm
@@ -23,32 +24,42 @@ def get_run_service(
 
 @router.post("", response_model=RunRead, status_code=status.HTTP_202_ACCEPTED)
 async def create_run(
-    payload: RunCreate, service: RunService = Depends(get_run_service)
+    payload: RunCreate,
+    service: RunService = Depends(get_run_service),
+    principal: AuthPrincipal = Depends(require_role(Role.OPERATOR)),
 ) -> RunRead:
     try:
-        run = await service.create_run(payload)
+        run = await service.create_run(payload, tenant_id=principal.tenant_id)
     except AgentNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Agent not found: {exc}") from exc
 
     await service.start_run(run.id)
-    run = await service.get_run(run.id, with_relations=True)
+    run = await service.get_run(
+        run.id, with_relations=True, tenant_id=principal.tenant_id
+    )
     return run_read_from_orm(run)
 
 
 @router.get("", response_model=list[RunRead])
 async def list_runs(
-    limit: int = 50, service: RunService = Depends(get_run_service)
+    limit: int = 50,
+    service: RunService = Depends(get_run_service),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> list[RunRead]:
-    runs = await service.list_runs(limit=limit)
+    runs = await service.list_runs(limit=limit, tenant_id=principal.tenant_id)
     return [run_read_from_orm(run) for run in runs]
 
 
 @router.get("/{run_id}", response_model=RunRead)
 async def get_run(
-    run_id: str, service: RunService = Depends(get_run_service)
+    run_id: str,
+    service: RunService = Depends(get_run_service),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> RunRead:
     try:
-        run = await service.get_run(run_id, with_relations=True)
+        run = await service.get_run(
+            run_id, with_relations=True, tenant_id=principal.tenant_id
+        )
     except RunNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
     return run_read_from_orm(run)
@@ -56,10 +67,12 @@ async def get_run(
 
 @router.post("/{run_id}/cancel", status_code=status.HTTP_204_NO_CONTENT)
 async def cancel_run(
-    run_id: str, service: RunService = Depends(get_run_service)
+    run_id: str,
+    service: RunService = Depends(get_run_service),
+    principal: AuthPrincipal = Depends(require_role(Role.OPERATOR)),
 ) -> None:
     try:
-        await service.cancel_run(run_id)
+        await service.cancel_run(run_id, tenant_id=principal.tenant_id)
     except RunNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
 
@@ -69,9 +82,12 @@ async def retry_run(
     run_id: str,
     payload: RunRetry | None = None,
     service: RunService = Depends(get_run_service),
+    principal: AuthPrincipal = Depends(require_role(Role.OPERATOR)),
 ) -> RunRead:
     try:
-        run = await service.retry_run(run_id, payload)
+        run = await service.retry_run(
+            run_id, payload, tenant_id=principal.tenant_id
+        )
     except RunNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
     except RunConflict as exc:
@@ -84,9 +100,12 @@ async def resume_run(
     run_id: str,
     payload: RunResume | None = None,
     service: RunService = Depends(get_run_service),
+    principal: AuthPrincipal = Depends(require_role(Role.OPERATOR)),
 ) -> RunRead:
     try:
-        run = await service.resume_run(run_id, payload)
+        run = await service.resume_run(
+            run_id, payload, tenant_id=principal.tenant_id
+        )
     except RunNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
     except RunConflict as exc:

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,0 +1,148 @@
+"""Simple API-key auth with tenant + role (viewer / operator / admin).
+
+Auth is off by default so local tests and quickstarts stay open. When
+``AGENTFLOW_AUTH_ENABLED=true``, every ``/v1/*`` request except health must
+present ``Authorization: Bearer <key>`` or ``X-Api-Key: <key>``. Keys are
+configured as ``key:tenant:role`` entries in ``AGENTFLOW_AUTH_API_KEYS``.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, status
+
+from app.core.config import Settings, get_settings
+from app.models.agent import DEFAULT_TENANT_ID
+
+
+class Role(IntEnum):
+    VIEWER = 1
+    OPERATOR = 2
+    ADMIN = 3
+
+    @classmethod
+    def parse(cls, value: str) -> Role:
+        try:
+            return cls[value.strip().upper()]
+        except KeyError as exc:
+            raise ValueError(f"Unknown role: {value}") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class AuthPrincipal:
+    tenant_id: str
+    role: Role
+    subject: str
+
+    def require(self, minimum: Role) -> None:
+        if self.role < minimum:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Requires role {minimum.name.lower()} or higher",
+            )
+
+
+_principal: ContextVar[AuthPrincipal | None] = ContextVar(
+    "auth_principal", default=None
+)
+
+
+def set_principal(principal: AuthPrincipal | None) -> None:
+    _principal.set(principal)
+
+
+def current_principal() -> AuthPrincipal | None:
+    return _principal.get()
+
+
+def parse_api_keys(raw: str) -> dict[str, AuthPrincipal]:
+    """Parse ``key:tenant:role[,key:tenant:role...]`` into a lookup map."""
+    out: dict[str, AuthPrincipal] = {}
+    for chunk in raw.split(","):
+        piece = chunk.strip()
+        if not piece:
+            continue
+        parts = piece.split(":")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Invalid auth key entry {piece!r}; expected key:tenant:role"
+            )
+        token, tenant_id, role_name = (p.strip() for p in parts)
+        if not token or not tenant_id:
+            raise ValueError(f"Invalid auth key entry {piece!r}")
+        out[token] = AuthPrincipal(
+            tenant_id=tenant_id,
+            role=Role.parse(role_name),
+            subject=token[:8],
+        )
+    return out
+
+
+def resolve_principal(
+    settings: Settings,
+    *,
+    authorization: str | None,
+    api_key: str | None,
+) -> AuthPrincipal:
+    if not settings.auth_enabled:
+        return AuthPrincipal(
+            tenant_id=DEFAULT_TENANT_ID,
+            role=Role.ADMIN,
+            subject="anonymous",
+        )
+
+    token = _extract_token(authorization=authorization, api_key=api_key)
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    keys = parse_api_keys(settings.auth_api_keys)
+    principal = keys.get(token)
+    if principal is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return principal
+
+
+def _extract_token(
+    *, authorization: str | None, api_key: str | None
+) -> str | None:
+    if api_key and api_key.strip():
+        return api_key.strip()
+    if authorization:
+        scheme, _, value = authorization.partition(" ")
+        if scheme.lower() == "bearer" and value.strip():
+            return value.strip()
+    return None
+
+
+async def get_principal(
+    authorization: Annotated[str | None, Header()] = None,
+    x_api_key: Annotated[str | None, Header(alias="X-Api-Key")] = None,
+    settings: Settings = Depends(get_settings),
+) -> AuthPrincipal:
+    principal = resolve_principal(
+        settings, authorization=authorization, api_key=x_api_key
+    )
+    set_principal(principal)
+    return principal
+
+
+def require_role(minimum: Role):
+    async def _dep(
+        principal: AuthPrincipal = Depends(get_principal),
+    ) -> AuthPrincipal:
+        principal.require(minimum)
+        return principal
+
+    return _dep

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -167,6 +167,21 @@ class Settings(BaseSettings):
     )
     cancel_ttl_seconds: int = 86400
 
+    auth_enabled: bool = Field(
+        default=False,
+        description=(
+            "When true, /v1 endpoints (except health) require an API key. "
+            "Keys are listed in auth_api_keys."
+        ),
+    )
+    auth_api_keys: str = Field(
+        default="",
+        description=(
+            "Comma-separated API keys as key:tenant_id:role "
+            "(role is viewer|operator|admin)."
+        ),
+    )
+
     openai_api_key: str | None = None
     openai_base_url: str = "https://api.openai.com/v1"
 

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -6,6 +6,8 @@ from ulid import ULID
 
 from app.db.base import Base
 
+DEFAULT_TENANT_ID = "default"
+
 
 def _ulid() -> str:
     return str(ULID())
@@ -21,12 +23,22 @@ class Agent(Base):
 
     ``version`` is a monotonic integer that bumps whenever adapter / config /
     description change; each bump is also stored in ``agent_versions``.
+
+    ``tenant_id`` scopes the agent to a single tenant; names are unique
+    within a tenant, not globally.
     """
 
     __tablename__ = "agents"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name", name="uq_agents_tenant_name"),
+        Index("ix_agents_tenant_id", "tenant_id"),
+    )
 
     id: Mapped[str] = mapped_column(String(26), primary_key=True, default=_ulid)
-    name: Mapped[str] = mapped_column(String(128), unique=True, index=True)
+    tenant_id: Mapped[str] = mapped_column(
+        String(64), default=DEFAULT_TENANT_ID, nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(128), index=True)
     description: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     adapter: Mapped[str] = mapped_column(String(64), default="echo")
     config: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)

--- a/backend/app/models/run.py
+++ b/backend/app/models/run.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ulid import ULID
 
 from app.db.base import Base
+from app.models.agent import DEFAULT_TENANT_ID
 
 
 def _ulid() -> str:
@@ -36,11 +37,20 @@ class Run(Base):
     A run is the top-level unit users observe and operate on (cancel, retry,
     resume). It owns an ordered stream of `Step` rows, which in turn own
     `Message` and `ToolCall` rows.
+
+    ``tenant_id`` mirrors the owning agent's tenant for query isolation.
     """
 
     __tablename__ = "runs"
+    __table_args__ = (
+        Index("ix_runs_tenant_id", "tenant_id"),
+        Index("ix_runs_tenant_created", "tenant_id", "created_at"),
+    )
 
     id: Mapped[str] = mapped_column(String(26), primary_key=True, default=_ulid)
+    tenant_id: Mapped[str] = mapped_column(
+        String(64), default=DEFAULT_TENANT_ID, nullable=False
+    )
     agent_id: Mapped[str] = mapped_column(
         ForeignKey("agents.id", ondelete="CASCADE"), index=True
     )

--- a/backend/app/schemas/agent.py
+++ b/backend/app/schemas/agent.py
@@ -29,6 +29,7 @@ class AgentRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
+    tenant_id: str
     name: str
     description: str | None
     adapter: str

--- a/backend/app/schemas/run.py
+++ b/backend/app/schemas/run.py
@@ -87,6 +87,7 @@ class RunRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
+    tenant_id: str
     agent_id: str
     adapter: str
     status: RunStatus

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -94,12 +94,15 @@ class RunService:
         self.job_queue = job_queue or get_job_queue()
         self.cancel_registry = cancel_registry or get_cancel_registry()
 
-    async def create_run(self, payload: RunCreate) -> Run:
+    async def create_run(
+        self, payload: RunCreate, *, tenant_id: str | None = None
+    ) -> Run:
         agent = await self.session.get(Agent, payload.agent_id)
-        if agent is None:
+        if agent is None or (tenant_id is not None and agent.tenant_id != tenant_id):
             raise AgentNotFound(payload.agent_id)
 
         run = Run(
+            tenant_id=agent.tenant_id,
             agent_id=agent.id,
             adapter=payload.adapter or agent.adapter,
             status=RunStatus.PENDING,
@@ -163,9 +166,15 @@ class RunService:
         finally:
             _running_tasks.pop(run_id, None)
 
-    async def retry_run(self, run_id: str, payload: RunRetry | None = None) -> Run:
+    async def retry_run(
+        self,
+        run_id: str,
+        payload: RunRetry | None = None,
+        *,
+        tenant_id: str | None = None,
+    ) -> Run:
         """Re-queue a failed run, optionally from a checkpoint snapshot."""
-        run = await self._get_run(run_id, with_relations=True)
+        run = await self._get_run(run_id, with_relations=True, tenant_id=tenant_id)
         if run.status != RunStatus.FAILED:
             raise RunConflict(run_id, run.status, "retry")
 
@@ -203,11 +212,17 @@ class RunService:
         await self.session.commit()
 
         await self.start_run(run_id)
-        return await self.get_run(run_id, with_relations=True)
+        return await self.get_run(run_id, with_relations=True, tenant_id=tenant_id)
 
-    async def resume_run(self, run_id: str, payload: RunResume | None = None) -> Run:
+    async def resume_run(
+        self,
+        run_id: str,
+        payload: RunResume | None = None,
+        *,
+        tenant_id: str | None = None,
+    ) -> Run:
         """Continue a run paused for human approval."""
-        run = await self._get_run(run_id, with_relations=True)
+        run = await self._get_run(run_id, with_relations=True, tenant_id=tenant_id)
         if run.status != RunStatus.WAITING_HUMAN:
             raise RunConflict(run_id, run.status, "resume")
 
@@ -238,12 +253,12 @@ class RunService:
         await self.session.commit()
 
         await self.start_run(run_id)
-        return await self.get_run(run_id, with_relations=True)
+        return await self.get_run(run_id, with_relations=True, tenant_id=tenant_id)
 
-    async def cancel_run(self, run_id: str) -> None:
+    async def cancel_run(self, run_id: str, *, tenant_id: str | None = None) -> None:
         # Ensure the run exists so the API returns 404 for unknown ids
         # whether or not a worker is currently executing it.
-        await self._get_run(run_id)
+        await self._get_run(run_id, tenant_id=tenant_id)
 
         # Signal external workers (queue mode) via the cancel registry.
         await self.cancel_registry.request_cancel(run_id)
@@ -258,18 +273,38 @@ class RunService:
         if get_settings().worker_mode == "inline":
             await self._finalize(run_id, RunStatus.CANCELLED, error="cancelled")
 
-    async def get_run(self, run_id: str, *, with_relations: bool = True) -> Run:
-        return await self._get_run(run_id, with_relations=with_relations)
+    async def get_run(
+        self,
+        run_id: str,
+        *,
+        with_relations: bool = True,
+        tenant_id: str | None = None,
+    ) -> Run:
+        return await self._get_run(
+            run_id, with_relations=with_relations, tenant_id=tenant_id
+        )
 
-    async def list_runs(self, limit: int = 50) -> list[Run]:
+    async def list_runs(
+        self, limit: int = 50, *, tenant_id: str | None = None
+    ) -> list[Run]:
         stmt = select(Run).order_by(Run.created_at.desc()).limit(limit)
+        if tenant_id is not None:
+            stmt = stmt.where(Run.tenant_id == tenant_id)
         result = await self.session.execute(stmt)
         return list(result.scalars())
 
     # ------------------------------------------------------------------ helpers
 
-    async def _get_run(self, run_id: str, *, with_relations: bool = False) -> Run:
+    async def _get_run(
+        self,
+        run_id: str,
+        *,
+        with_relations: bool = False,
+        tenant_id: str | None = None,
+    ) -> Run:
         stmt = select(Run).where(Run.id == run_id)
+        if tenant_id is not None:
+            stmt = stmt.where(Run.tenant_id == tenant_id)
         if with_relations:
             stmt = stmt.options(
                 selectinload(Run.steps).selectinload(Step.tool_calls),

--- a/backend/tests/test_auth_tenant.py
+++ b/backend/tests/test_auth_tenant.py
@@ -1,0 +1,107 @@
+"""Multi-tenant isolation and role checks (API key auth)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import get_settings
+
+
+@pytest.fixture
+async def authed_client(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AGENTFLOW_AUTH_ENABLED", "true")
+    monkeypatch.setenv(
+        "AGENTFLOW_AUTH_API_KEYS",
+        "admin-a:tenant-a:admin,viewer-a:tenant-a:viewer,"
+        "admin-b:tenant-b:admin,ops-a:tenant-a:operator",
+    )
+    get_settings.cache_clear()
+
+    # Re-import app after settings change so Depends(get_settings) sees new values.
+    from app.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        async with app.router.lifespan_context(app):
+            yield ac
+
+    get_settings.cache_clear()
+    os.environ.pop("AGENTFLOW_AUTH_ENABLED", None)
+    os.environ.pop("AGENTFLOW_AUTH_API_KEYS", None)
+
+
+@pytest.mark.asyncio
+async def test_missing_key_returns_401(authed_client: AsyncClient) -> None:
+    response = await authed_client.get("/v1/agents")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_health_stays_open(authed_client: AsyncClient) -> None:
+    response = await authed_client.get("/v1/health")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_viewer_cannot_create_agent(authed_client: AsyncClient) -> None:
+    response = await authed_client.post(
+        "/v1/agents",
+        headers={"Authorization": "Bearer viewer-a"},
+        json={"name": "blocked", "adapter": "echo"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolation(authed_client: AsyncClient) -> None:
+    created = await authed_client.post(
+        "/v1/agents",
+        headers={"X-Api-Key": "admin-a"},
+        json={"name": "writer", "adapter": "echo"},
+    )
+    assert created.status_code == 201
+    body = created.json()
+    assert body["tenant_id"] == "tenant-a"
+    agent_id = body["id"]
+
+    other = await authed_client.get(
+        f"/v1/agents/{agent_id}",
+        headers={"Authorization": "Bearer admin-b"},
+    )
+    assert other.status_code == 404
+
+    same = await authed_client.get(
+        f"/v1/agents/{agent_id}",
+        headers={"Authorization": "Bearer viewer-a"},
+    )
+    assert same.status_code == 200
+    assert same.json()["id"] == agent_id
+
+
+@pytest.mark.asyncio
+async def test_operator_can_create_run(authed_client: AsyncClient) -> None:
+    agent = await authed_client.post(
+        "/v1/agents",
+        headers={"Authorization": "Bearer admin-a"},
+        json={"name": "runner", "adapter": "echo"},
+    )
+    assert agent.status_code == 201
+    agent_id = agent.json()["id"]
+
+    denied = await authed_client.post(
+        "/v1/runs",
+        headers={"Authorization": "Bearer viewer-a"},
+        json={"agent_id": agent_id, "input": {"prompt": "hi"}},
+    )
+    assert denied.status_code == 403
+
+    run = await authed_client.post(
+        "/v1/runs",
+        headers={"Authorization": "Bearer ops-a"},
+        json={"agent_id": agent_id, "input": {"prompt": "hi"}},
+    )
+    assert run.status_code == 202
+    assert run.json()["tenant_id"] == "tenant-a"

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -15,6 +15,20 @@ below are relative to that backend root.
 - JSON keys use `snake_case`. The frontend types in
   [`frontend/lib/types.ts`](../frontend/lib/types.ts) are the source of truth.
 - Errors return `{"detail": "<message>"}` with a non-2xx status code.
+- **Auth (optional).** When `AGENTFLOW_AUTH_ENABLED=true`, every `/v1/*`
+  endpoint except `GET /v1/health` requires
+  `Authorization: Bearer <api-key>` or `X-Api-Key: <api-key>`. Each key maps
+  to a `tenant_id` and role (`viewer` | `operator` | `admin`). Cross-tenant
+  resources return 404. Missing key → 401; insufficient role → 403.
+  Auth is **off by default** for local development.
+
+### Roles
+
+| Role | Capabilities |
+| --- | --- |
+| `viewer` | List/get agents, runs, versions, SSE |
+| `operator` | viewer + create/cancel/retry/resume runs |
+| `admin` | operator + create/update/restore agents |
 
 ## Endpoints
 
@@ -326,6 +340,7 @@ the runtime falls back to the oldest incomplete call with a matching name.
 ```ts
 {
   id: string;
+  tenant_id: string;
   name: string;
   description: string | null;
   adapter: string;
@@ -335,6 +350,9 @@ the runtime falls back to the oldest incomplete call with a matching name.
   updated_at: string;
 }
 ```
+
+`tenant_id` is assigned from the caller's API key (or `"default"` when auth
+is disabled). Agent `name` is unique **per tenant**.
 
 ### `AgentVersion`
 
@@ -372,6 +390,7 @@ the runtime falls back to the oldest incomplete call with a matching name.
 ```ts
 {
   id: string;
+  tenant_id: string;
   agent_id: string;
   adapter: string;
   status: "pending" | "running" | "succeeded" | "failed" | "cancelled" | "waiting_human";

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -18,6 +18,7 @@ erDiagram
 
     Agent {
         string id PK
+        string tenant_id
         string name UK
         string adapter
         json config
@@ -33,6 +34,7 @@ erDiagram
     }
     Run {
         string id PK
+        string tenant_id
         string agent_id FK
         string adapter
         string status
@@ -103,6 +105,8 @@ stateDiagram-v2
 
 ## Design notes
 
+- **`tenant_id`** scopes agents and runs. Names are unique within a tenant
+  (`uq_agents_tenant_name`). List/get APIs filter by the caller's tenant.
 - **`Agent.version`** is a monotonic integer. Each bump also writes an
   immutable ``agent_versions`` snapshot (adapter + config + description).
   Restore creates a new version rather than rewriting history.
@@ -126,6 +130,10 @@ stateDiagram-v2
 
 | Index | Purpose |
 | --- | --- |
+| `uq_agents_tenant_name` | unique agent name per tenant |
+| `ix_agents_tenant_id` | list agents for a tenant |
+| `ix_runs_tenant_id` | filter runs by tenant |
+| `ix_runs_tenant_created` | tenant-scoped recent runs |
 | `ix_runs_status` | filter pending / running runs from a worker |
 | `ix_runs_agent_id` | list runs for an agent |
 | `ix_steps_run_index` | render the step timeline in O(log n) |

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -59,6 +59,7 @@
 **目标：** 多租户安全部署、治理与长任务。
 
 - [ ] OIDC 认证与服务账号 API Key
+- [x] 简易 API Key 多租户 + RBAC（`tenant_id`、viewer/operator/admin；OIDC 仍待做）
 - [ ] RBAC：组织/项目/Agent 作用域；cancel/resume 审计
 - [ ] 人工审批 UI（`waiting_human` + 通知）
 - [ ] Temporal（或 Restate）集成超长 Run

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,7 @@
 AGENTFLOW_API_URL=http://localhost:8000
+
+# When the API has auth enabled, set the same key here so the console and
+# SSE proxy can call /v1. Prefer AGENTFLOW_API_KEY (server-only) for SSE;
+# NEXT_PUBLIC_ is needed for browser fetch.
+# AGENTFLOW_API_KEY=dev-admin
+# NEXT_PUBLIC_AGENTFLOW_API_KEY=dev-admin

--- a/frontend/app/api/v1/events/[runId]/route.ts
+++ b/frontend/app/api/v1/events/[runId]/route.ts
@@ -27,6 +27,11 @@ export async function GET(
   if (lastEventId) {
     headers["Last-Event-ID"] = lastEventId;
   }
+  const apiKey =
+    process.env.AGENTFLOW_API_KEY || process.env.NEXT_PUBLIC_AGENTFLOW_API_KEY;
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
 
   const upstream = await fetch(url.toString(), {
     headers,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,11 +1,18 @@
 import type { Agent, AgentVersion, AgentVersionDiff, Run } from "./types";
 import { normalizeUsage } from "./usage";
 
+function authHeaders(): Record<string, string> {
+  const key = process.env.NEXT_PUBLIC_AGENTFLOW_API_KEY;
+  if (!key) return {};
+  return { Authorization: `Bearer ${key}` };
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`/api${path}`, {
     ...init,
     headers: {
       "Content-Type": "application/json",
+      ...authHeaders(),
       ...(init?.headers || {}),
     },
     cache: "no-store",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -63,6 +63,7 @@ export interface Checkpoint {
 
 export interface Run {
   id: string;
+  tenant_id: string;
   agent_id: string;
   adapter: string;
   status: RunStatus;
@@ -79,6 +80,7 @@ export interface Run {
 
 export interface Agent {
   id: string;
+  tenant_id: string;
   name: string;
   description: string | null;
   adapter: string;


### PR DESCRIPTION
- Added support for multi-tenant API key authentication, allowing endpoints to require authorization based on tenant and role.
- Introduced new environment variables `AGENTFLOW_AUTH_ENABLED` and `AGENTFLOW_AUTH_API_KEYS` for configuration.
- Updated the database schema to include `tenant_id` in `agents` and `runs` for tenant isolation.
- Modified API endpoints to enforce tenant-based access control.
- Added tests to verify tenant isolation and role-based access control.