### PR TITLE
feat(pydantic-ai): expose AgentFlow-managed tools

### DIFF
--- a/integrations/pydantic-ai/README.md
+++ b/integrations/pydantic-ai/README.md
@@ -45,7 +45,7 @@ validators, and output type. Returning a fresh Agent per run avoids accidental
 state sharing between runs.
 
 Install the MCP client extra when the factory uses `MCPToolset` or the config
-supplies `mcp_servers`:
+uses MCP tools via `mcp_auto_register` or an explicit `mcp/<server>/<tool>` entry:
 
 ```bash
 pip install "agentflow-pydantic-ai[mcp]"

--- a/integrations/pydantic-ai/README.md
+++ b/integrations/pydantic-ai/README.md
@@ -44,7 +44,8 @@ The factory owns the PydanticAI model, instructions, tools, MCP servers,
 validators, and output type. Returning a fresh Agent per run avoids accidental
 state sharing between runs.
 
-Install the MCP client extra when the factory uses `MCPToolset`:
+Install the MCP client extra when the factory uses `MCPToolset` or the config
+supplies `mcp_servers`:
 
 ```bash
 pip install "agentflow-pydantic-ai[mcp]"
@@ -56,10 +57,15 @@ pip install "agentflow-pydantic-ai[mcp]"
 {
   "adapter": "pydantic-ai",
   "config": {
-    "agent_factory": "myapp.agents:create_agent"
+    "agent_factory": "myapp.agents:create_agent",
+    "tools": ["echo"]
   }
 }
 ```
+
+`tools`, `mcp_servers`, and `mcp_auto_register` use the same format as other
+AgentFlow adapters. The adapter exposes resolved tools to PydanticAI for the
+current run and delegates their execution back to `AdapterToolSurface`.
 
 `agent_factory` imports and executes trusted Python code in the worker process.
 Only administrators should be allowed to configure it; this plugin is not a
@@ -69,6 +75,6 @@ One PydanticAI run maps to one AgentFlow step. The plugin emits user and
 assistant messages, token deltas, provider usage/cost when available, and
 AgentFlow-owned ToolCall IDs for PydanticAI function-tool and MCP events.
 
-The MVP deliberately does not rebuild Agents from JSON, route tools through
-`AdapterToolSurface`, or implement checkpoint/retry, HITL, and deferred tools.
+The plugin deliberately does not rebuild Agents from JSON or implement
+checkpoint/retry, HITL, and deferred tools.
 PydanticAI 2.27 or later in the 2.x series is supported.

--- a/integrations/pydantic-ai/src/agentflow_pydantic_ai/__init__.py
+++ b/integrations/pydantic-ai/src/agentflow_pydantic_ai/__init__.py
@@ -1,8 +1,9 @@
 """Official PydanticAI adapter plugin for AgentFlow."""
 
 from agentflow_pydantic_ai.adapter import PydanticAIAdapter
+from agentflow_pydantic_ai.toolset import AgentFlowToolset
 
-__all__ = ["PydanticAIAdapter", "create_adapter"]
+__all__ = ["AgentFlowToolset", "PydanticAIAdapter", "create_adapter"]
 
 
 def create_adapter() -> PydanticAIAdapter:

--- a/integrations/pydantic-ai/src/agentflow_pydantic_ai/adapter.py
+++ b/integrations/pydantic-ai/src/agentflow_pydantic_ai/adapter.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from contextlib import AsyncExitStack
 from importlib import import_module
 from typing import Any
 
+from app.adapters.adapter_tools import open_tool_surface
 from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
 from app.core.logging import get_logger
 from app.models.run import RunStatus
@@ -24,6 +26,8 @@ from pydantic_ai import (
 )
 from pydantic_core import to_jsonable_python
 
+from agentflow_pydantic_ai.toolset import AgentFlowToolset
+
 logger = get_logger("adapter.pydantic_ai")
 
 DEFAULT_NODE = "pydantic_ai"
@@ -39,6 +43,7 @@ class PydanticAIAdapter(OrchestratorAdapter):
         node = str(ctx.agent_config.get("node") or DEFAULT_NODE)
         prompt = prompt_from_input(ctx.input)
         active_tools: dict[str, tuple[str, str, float]] = {}
+        bridged_tool_calls: set[str] = set()
 
         await ctx.emit_step_started(index=step_index, node=node)
         await ctx.emit_message(role="user", content=prompt)
@@ -46,29 +51,44 @@ class PydanticAIAdapter(OrchestratorAdapter):
 
         try:
             agent = load_agent(ctx.agent_config.get("agent_factory"))
+            async with AsyncExitStack() as stack:
+                bridge: AgentFlowToolset | None = None
+                if uses_agentflow_tools(ctx.agent_config):
+                    surface = await stack.enter_async_context(open_tool_surface(ctx.agent_config))
+                    if surface.tools:
+                        bridge = AgentFlowToolset(surface, ctx, step_index)
 
-            async with agent.run_stream_events(
-                prompt,
-                run_id=ctx.run_id,
-                metadata=dict(ctx.metadata) or None,
-            ) as events:
-                async for event in events:
-                    if delta := text_delta(event):
-                        await ctx.emit_token_delta(step_index=step_index, delta=delta)
-                    elif isinstance(event, FunctionToolCallEvent):
-                        call_id = await ctx.emit_tool_call_started(
-                            step_index=step_index,
-                            name=event.part.tool_name,
-                            arguments=event.part.args_as_dict(),
-                        )
-                        active_tools[event.tool_call_id] = (
-                            event.part.tool_name,
-                            call_id,
-                            time.monotonic(),
-                        )
-                    elif isinstance(event, FunctionToolResultEvent):
-                        await emit_tool_result(ctx, step_index, event, active_tools)
-                result = events.result
+                async with agent.run_stream_events(
+                    prompt,
+                    run_id=ctx.run_id,
+                    metadata=dict(ctx.metadata) or None,
+                    toolsets=[bridge] if bridge is not None else None,
+                ) as events:
+                    async for event in events:
+                        if delta := text_delta(event):
+                            await ctx.emit_token_delta(step_index=step_index, delta=delta)
+                        elif isinstance(event, FunctionToolCallEvent):
+                            if bridge is not None and bridge.owns(event.part.tool_name):
+                                bridged_tool_calls.add(event.tool_call_id)
+                                continue
+                            call_id = await ctx.emit_tool_call_started(
+                                step_index=step_index,
+                                name=event.part.tool_name,
+                                arguments=event.part.args_as_dict(),
+                            )
+                            active_tools[event.tool_call_id] = (
+                                event.part.tool_name,
+                                call_id,
+                                time.monotonic(),
+                            )
+                        elif isinstance(event, FunctionToolResultEvent):
+                            if event.tool_call_id in bridged_tool_calls or (
+                                bridge is not None and bridge.owns(event.part.tool_name)
+                            ):
+                                bridged_tool_calls.discard(event.tool_call_id)
+                                continue
+                            await emit_tool_result(ctx, step_index, event, active_tools)
+                    result = events.result
 
             if result is None:
                 raise RuntimeError("PydanticAI run ended without a final result")
@@ -100,6 +120,11 @@ class PydanticAIAdapter(OrchestratorAdapter):
             await close_active_tools(ctx, step_index, active_tools, error)
             await ctx.emit_step_failed(index=step_index, node=node, error=error)
             return AdapterResult(status=RunStatus.FAILED, error=error)
+
+
+def uses_agentflow_tools(config: dict[str, Any]) -> bool:
+    """Return whether this run asks AgentFlow to inject managed tools."""
+    return bool(config.get("tools") or config.get("mcp_auto_register"))
 
 
 def load_agent(reference: Any) -> Agent[Any, Any]:

--- a/integrations/pydantic-ai/src/agentflow_pydantic_ai/toolset.py
+++ b/integrations/pydantic-ai/src/agentflow_pydantic_ai/toolset.py
@@ -1,0 +1,110 @@
+"""Expose AgentFlow-managed tools as a per-run PydanticAI toolset."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from copy import deepcopy
+from typing import Any
+
+from app.adapters.adapter_tools import AdapterToolSurface
+from app.adapters.base import AdapterContext
+from app.adapters.tool_registry import ToolDefinition as AgentFlowToolDefinition
+from pydantic_ai import RunContext
+from pydantic_ai.tools import ToolDefinition as PydanticAIToolDefinition
+from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
+from pydantic_core import SchemaValidator, core_schema
+
+_MAX_TOOL_NAME_LENGTH = 64
+_SAFE_TOOL_NAME = re.compile(r"^[A-Za-z0-9_-]+$")
+_UNSAFE_TOOL_NAME = re.compile(r"[^A-Za-z0-9_-]+")
+_ARGUMENTS_VALIDATOR = SchemaValidator(core_schema.dict_schema())
+
+
+def pydantic_tool_name(name: str) -> str:
+    """Return a provider-safe name while keeping common registry keys readable."""
+    if name and len(name) <= _MAX_TOOL_NAME_LENGTH and _SAFE_TOOL_NAME.fullmatch(name):
+        return name
+
+    normalized = _UNSAFE_TOOL_NAME.sub("__", name).strip("_") or "tool"
+    if len(normalized) <= _MAX_TOOL_NAME_LENGTH:
+        return normalized
+
+    digest = hashlib.sha256(name.encode()).hexdigest()[:8]
+    prefix_length = _MAX_TOOL_NAME_LENGTH - len(digest) - 1
+    return f"{normalized[:prefix_length]}_{digest}"
+
+
+class AgentFlowToolset(AbstractToolset[Any]):
+    """Translate and execute tools resolved through ``AdapterToolSurface``."""
+
+    def __init__(
+        self,
+        surface: AdapterToolSurface,
+        adapter_ctx: AdapterContext,
+        step_index: int,
+    ) -> None:
+        self._surface = surface
+        self._adapter_ctx = adapter_ctx
+        self._step_index = step_index
+        self._tools: dict[str, AgentFlowToolDefinition] = {}
+
+        for tool in surface.tools:
+            exposed_name = pydantic_tool_name(tool.name)
+            existing = self._tools.get(exposed_name)
+            if existing is not None and existing.name != tool.name:
+                raise ValueError(
+                    "AgentFlow tool names "
+                    f"{existing.name!r} and {tool.name!r} both map to "
+                    f"PydanticAI name {exposed_name!r}"
+                )
+            self._tools[exposed_name] = tool
+
+    @property
+    def id(self) -> str:
+        return "agentflow-runtime"
+
+    @property
+    def exposed_names(self) -> frozenset[str]:
+        """Names visible to PydanticAI and model providers for this run."""
+        return frozenset(self._tools)
+
+    def owns(self, name: str | None) -> bool:
+        """Return whether an event belongs to an AgentFlow-managed tool."""
+        return name in self._tools if name is not None else False
+
+    async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
+        del ctx
+        return {
+            exposed_name: ToolsetTool(
+                toolset=self,
+                tool_def=PydanticAIToolDefinition(
+                    name=exposed_name,
+                    description=tool.description or f"Invoke the {tool.name} tool.",
+                    parameters_json_schema=deepcopy(tool.parameters)
+                    or {"type": "object", "properties": {}},
+                    metadata={"agentflow_tool_name": tool.name},
+                ),
+                max_retries=0,
+                args_validator=_ARGUMENTS_VALIDATOR,
+            )
+            for exposed_name, tool in self._tools.items()
+        }
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[Any],
+        tool: ToolsetTool[Any],
+    ) -> Any:
+        del ctx, tool
+        definition = self._tools.get(name)
+        if definition is None:
+            raise KeyError(f"Unknown AgentFlow tool: {name!r}")
+        return await self._surface.execute(
+            self._adapter_ctx,
+            step_index=self._step_index,
+            name=definition.name,
+            arguments=tool_args,
+        )

--- a/integrations/pydantic-ai/tests/test_adapter.py
+++ b/integrations/pydantic-ai/tests/test_adapter.py
@@ -4,12 +4,14 @@ from typing import Any
 
 import pytest
 from app.adapters.base import AdapterContext
+from app.adapters.tool_registry import register_tool
 from app.models.run import RunStatus
 from pydantic_ai import Agent
 from pydantic_ai.models.function import DeltaToolCall, FunctionModel
 from pydantic_ai.models.test import TestModel
 
 from agentflow_pydantic_ai import PydanticAIAdapter, create_adapter
+from agentflow_pydantic_ai.toolset import pydantic_tool_name
 
 
 class RecordingContext(AdapterContext):
@@ -64,8 +66,31 @@ def tool_agent() -> Agent[None, str]:
     return agent
 
 
+def bridged_tool_agent() -> Agent[None, str]:
+    return Agent(TestModel(call_tools=["echo"]))
+
+
+def mixed_tool_agent() -> Agent[None, str]:
+    agent = Agent(TestModel(call_tools=["echo", "local_upper"]))
+
+    @agent.tool_plain
+    async def local_upper(text: str) -> dict[str, str]:
+        return {"text": text.upper()}
+
+    return agent
+
+
+def failing_tool_agent() -> Agent[None, str]:
+    return Agent(TestModel(call_tools=["bridge_failure"]))
+
+
 def not_an_agent() -> object:
     return object()
+
+
+def test_mcp_tool_names_are_provider_safe() -> None:
+    assert pydantic_tool_name("mcp/knowledge/search") == "mcp__knowledge__search"
+    assert len(pydantic_tool_name("mcp/" + "x" * 100)) == 64
 
 
 @pytest.mark.asyncio
@@ -104,6 +129,55 @@ async def test_native_tool_events_use_agentflow_ids() -> None:
     assert completed["call_id"] == started["call_id"]
     assert completed["result"] == {"text": "ping"}
     assert completed["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_agentflow_builtin_tool_is_injected_without_duplicate_events() -> None:
+    ctx = RecordingContext(factory_reference("bridged_tool_agent"))
+    ctx.agent_config["tools"] = ["echo"]
+
+    result = await PydanticAIAdapter().run(ctx)
+
+    assert result.status == RunStatus.SUCCEEDED
+    started = ctx.event("tool_call.started")
+    completed = ctx.event("tool_call.completed")
+    assert len(started) == len(completed) == 1
+    assert started[0]["name"] == "echo"
+    assert completed[0]["result"] == {"text": ""}
+    assert completed[0]["call_id"] == started[0]["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_agentflow_and_factory_tools_can_run_together() -> None:
+    ctx = RecordingContext(factory_reference("mixed_tool_agent"))
+    ctx.agent_config["tools"] = ["echo"]
+
+    result = await PydanticAIAdapter().run(ctx)
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert {event["name"] for event in ctx.event("tool_call.started")} == {
+        "echo",
+        "local_upper",
+    }
+    assert len(ctx.event("tool_call.completed")) == 2
+
+
+@pytest.mark.asyncio
+async def test_agentflow_tool_failure_is_emitted_once() -> None:
+    async def fail(_arguments: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("bridge exploded")
+
+    register_tool("bridge_failure", fail, overwrite=True)
+    ctx = RecordingContext(factory_reference("failing_tool_agent"))
+    ctx.agent_config["tools"] = ["bridge_failure"]
+
+    result = await PydanticAIAdapter().run(ctx)
+
+    assert result.status == RunStatus.FAILED
+    assert result.error == "bridge exploded"
+    assert len(ctx.event("tool_call.started")) == 1
+    assert len(ctx.event("tool_call.completed")) == 1
+    assert ctx.event("tool_call.completed")[0]["error"] == "bridge exploded"
 
 
 @pytest.mark.asyncio

--- a/integrations/pydantic-ai/tests/test_adapter.py
+++ b/integrations/pydantic-ai/tests/test_adapter.py
@@ -167,7 +167,7 @@ async def test_agentflow_tool_failure_is_emitted_once() -> None:
     async def fail(_arguments: dict[str, Any]) -> dict[str, Any]:
         raise RuntimeError("bridge exploded")
 
-    register_tool("bridge_failure", fail, overwrite=True)
+    register_tool("bridge_failure", fail)
     ctx = RecordingContext(factory_reference("failing_tool_agent"))
     ctx.agent_config["tools"] = ["bridge_failure"]
 


### PR DESCRIPTION
## Summary

- resolve `tools`, `mcp_servers`, and `mcp_auto_register` through the shared `AdapterToolSurface`
- expose resolved definitions as a per-run PydanticAI toolset with provider-safe names while retaining original AgentFlow names for execution and audit events
- delegate managed tool calls back to AgentFlow, suppress duplicate PydanticAI tool events, and preserve factory-native tools
- document the configuration and cover injection, native-tool coexistence, safe MCP names, and failure event handling

## Validation

- `pytest -q integrations/pydantic-ai/tests` — 7 passed
- `ruff check integrations/pydantic-ai` — passed
- `ruff format --check integrations/pydantic-ai` — passed
- `mypy src` — passed

## Existing test issue

An expanded local backend subset produced 26 passes and 4 failures because the existing `backend/tests/fixtures/mcp_echo_server.py` references `Server` and `stdio_server` without importing them under the local MCP 2.x environment. This PR does not modify that fixture or `docs/plan.md`.