### PR TITLE
Add Dependabot, outdated-deps, CodeQL, and scheduled CI issue automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+# Dependabot: open PRs for dependency upgrades across ecosystems.
+# Companion: .github/workflows/outdated-deps.yml opens a summary Issue.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      frontend-production:
+        dependency-type: production
+      frontend-development:
+        dependency-type: development
+
+  - package-ecosystem: maven
+    directory: /backend-java
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - java
+
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+
+  - package-ecosystem: pip
+    directory: /integrations/pydantic-ai
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          # uv.lock is gitignored; key cache on project manifests instead.
+          cache-dependency-glob: |
+            **/pyproject.toml
       - name: Install
         working-directory: backend
         run: uv sync --all-extras
@@ -77,6 +80,8 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
       - name: Install Python deps
         working-directory: backend
         run: uv sync --all-extras

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    # Daily health check at 05:00 UTC; failures open/refresh an Issue.
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   backend:
@@ -104,3 +112,85 @@ jobs:
       - name: Build
         working-directory: frontend
         run: npm run build
+
+  report-scheduled-failure:
+    name: Open Issue on scheduled CI failure
+    runs-on: ubuntu-latest
+    needs: [backend, backend-java, integration, frontend]
+    if: |
+      always() &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      (
+        needs.backend.result == 'failure' ||
+        needs.backend-java.result == 'failure' ||
+        needs.integration.result == 'failure' ||
+        needs.frontend.result == 'failure'
+      )
+    steps:
+      - uses: actions/checkout@v4
+      - name: Write failure report and upsert Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BACKEND_RESULT: ${{ needs.backend.result }}
+          JAVA_RESULT: ${{ needs.backend-java.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/upsert_automation_issue.sh
+          REPORT="ci-failure-report.md"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "# Scheduled CI failure"
+            echo
+            echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+            echo
+            echo "Workflow run: ${RUN_URL}"
+            echo
+            echo "| Job | Result |"
+            echo "|---|---|"
+            echo "| backend | \`${BACKEND_RESULT}\` |"
+            echo "| backend-java | \`${JAVA_RESULT}\` |"
+            echo "| integration | \`${INTEGRATION_RESULT}\` |"
+            echo "| frontend | \`${FRONTEND_RESULT}\` |"
+            echo
+            echo "This issue is refreshed while scheduled/manual CI keeps failing."
+            echo "Close it after the failing jobs are green again."
+          } >"$REPORT"
+
+          scripts/ci/upsert_automation_issue.sh \
+            "[automation] Scheduled CI failure" \
+            "$REPORT" \
+            automation \
+            ci-failure
+
+  close-scheduled-success:
+    name: Close CI failure Issue when green
+    runs-on: ubuntu-latest
+    needs: [backend, backend-java, integration, frontend]
+    if: |
+      always() &&
+      github.event_name == 'schedule' &&
+      needs.backend.result == 'success' &&
+      needs.backend-java.result == 'success' &&
+      needs.integration.result == 'success' &&
+      needs.frontend.result == 'success'
+    steps:
+      - name: Close open automation CI failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="[automation] Scheduled CI failure"
+          EXISTING="$(
+            gh issue list --state open --limit 100 --json number,title \
+              | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+              | head -n 1
+          )"
+          if [[ -n "$EXISTING" ]]; then
+            gh issue comment "$EXISTING" --body "Scheduled CI is green again. Closing. Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            gh issue close "$EXISTING" --reason completed
+            echo "Closed issue #${EXISTING}"
+          else
+            echo "No open CI failure issue."
+          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,147 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Wednesdays 06:00 UTC
+    - cron: "0 6 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: java
+            build-mode: manual
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        if: matrix.language == 'java'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Build Java for CodeQL
+        if: matrix.language == 'java'
+        working-directory: backend-java
+        run: mvn -B -DskipTests package
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  open-issue:
+    name: Summarize open alerts as Issue
+    needs: analyze
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build alert summary and upsert Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ci/upsert_automation_issue.sh
+
+          ALERTS_JSON="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/code-scanning/alerts?state=open&per_page=100" \
+            || echo '[]')"
+
+          COUNT="$(echo "$ALERTS_JSON" | jq 'if type=="array" then length else 0 end')"
+          REPORT="codeql-alerts-report.md"
+
+          {
+            echo "# CodeQL / code scanning open alerts"
+            echo
+            echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+            echo
+            echo "Open alerts: **${COUNT}**"
+            echo
+            echo "Alerts also appear under the repository **Security → Code scanning** tab."
+            echo
+            echo "Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo
+          } >"$REPORT"
+
+          TITLE="[automation] CodeQL open alerts"
+
+          if [[ "$COUNT" -eq 0 ]]; then
+            EXISTING="$(
+              gh issue list --state open --limit 100 --json number,title \
+                | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+                | head -n 1
+            )"
+            if [[ -n "$EXISTING" ]]; then
+              gh issue comment "$EXISTING" --body "No open code scanning alerts remain. Closing. Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              gh issue close "$EXISTING" --reason completed
+              echo "Closed issue #${EXISTING}"
+            else
+              echo "No open alerts and no tracking issue."
+            fi
+            exit 0
+          fi
+
+          {
+            echo "| Severity | Rule | Path | State | URL |"
+            echo "|---|---|---|---|---|"
+            echo "$ALERTS_JSON" | jq -r '
+              .[] |
+              [
+                (.rule.security_severity_level // .rule.severity // "unknown"),
+                (.rule.id // .rule.name // "unknown"),
+                (.most_recent_instance.location.path // "n/a"),
+                .state,
+                .html_url
+              ] | @tsv
+            ' | while IFS=$'\t' read -r sev rule path state url; do
+              echo "| ${sev} | \`${rule}\` | \`${path}\` | ${state} | [alert](${url}) |"
+            done
+            echo
+            echo "<details><summary>Raw alert JSON (truncated)</summary>"
+            echo
+            echo '```json'
+            echo "$ALERTS_JSON" | jq '.[0:20]'
+            echo '```'
+            echo
+            echo "</details>"
+          } >>"$REPORT"
+
+          scripts/ci/upsert_automation_issue.sh \
+            "$TITLE" \
+            "$REPORT" \
+            automation \
+            security

--- a/.github/workflows/outdated-deps.yml
+++ b/.github/workflows/outdated-deps.yml
@@ -1,0 +1,53 @@
+name: Outdated dependencies
+
+on:
+  schedule:
+    # Mondays 07:00 UTC
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: outdated-deps
+  cancel-in-progress: true
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Collect outdated dependency report
+        run: |
+          chmod +x scripts/ci/outdated_deps_report.sh
+          scripts/ci/outdated_deps_report.sh outdated-deps-report.md
+
+      - name: Upsert GitHub Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x scripts/ci/upsert_automation_issue.sh
+          scripts/ci/upsert_automation_issue.sh \
+            "[automation] Outdated dependencies" \
+            outdated-deps-report.md \
+            automation \
+            dependencies

--- a/.github/workflows/outdated-deps.yml
+++ b/.github/workflows/outdated-deps.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
 
       - uses: actions/setup-java@v4
         with:

--- a/scripts/ci/outdated_deps_report.sh
+++ b/scripts/ci/outdated_deps_report.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Collect outdated dependency reports for npm / Python (uv) / Maven.
+# Writes markdown to the path given as $1 (default: outdated-deps-report.md).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT="${1:-outdated-deps-report.md}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+section() {
+  local title="$1"
+  local body_file="$2"
+  {
+    echo "## ${title}"
+    echo
+    if [[ ! -s "$body_file" ]]; then
+      echo "_No outdated packages reported (or scan produced no output)._"
+    else
+      echo '```'
+      cat "$body_file"
+      echo '```'
+    fi
+    echo
+  } >>"$OUT"
+}
+
+: >"$OUT"
+{
+  echo "# Outdated dependencies report"
+  echo
+  echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+  echo
+  echo "This issue is updated by the scheduled \`outdated-deps\` workflow."
+  echo "Dependabot may also open upgrade PRs for the same ecosystems."
+  echo
+} >>"$OUT"
+
+# --- frontend (npm) ---
+if [[ -f "$ROOT/frontend/package-lock.json" ]]; then
+  (
+    cd "$ROOT/frontend"
+    npm ci --ignore-scripts >/dev/null 2>&1 || npm install --ignore-scripts >/dev/null 2>&1
+    # npm outdated exits 1 when outdated packages exist
+    npm outdated --long >"$TMP/npm.txt" 2>&1 || true
+  )
+  section "Frontend (npm)" "$TMP/npm.txt"
+else
+  echo "## Frontend (npm)" >>"$OUT"
+  echo >>"$OUT"
+  echo "_Skipped: no package-lock.json._" >>"$OUT"
+  echo >>"$OUT"
+fi
+
+# --- backend (uv / pip) ---
+if [[ -f "$ROOT/backend/pyproject.toml" ]]; then
+  (
+    cd "$ROOT/backend"
+    uv sync --all-extras >/dev/null 2>&1
+    uv pip list --outdated >"$TMP/backend-pip.txt" 2>&1 || true
+  )
+  section "Backend (Python / uv)" "$TMP/backend-pip.txt"
+fi
+
+# --- integrations/pydantic-ai ---
+if [[ -f "$ROOT/integrations/pydantic-ai/pyproject.toml" ]]; then
+  (
+    cd "$ROOT/integrations/pydantic-ai"
+    uv sync >/dev/null 2>&1 || uv pip install -e ".[dev]" >/dev/null 2>&1 || true
+    uv pip list --outdated >"$TMP/integ-pip.txt" 2>&1 || true
+  )
+  section "integrations/pydantic-ai (Python / uv)" "$TMP/integ-pip.txt"
+fi
+
+# --- backend-java (Maven) ---
+if [[ -f "$ROOT/backend-java/pom.xml" ]]; then
+  (
+    cd "$ROOT/backend-java"
+    mvn -B -q \
+      org.codehaus.mojo:versions-maven-plugin:2.17.1:display-dependency-updates \
+      -DprocessDependencyManagement=true \
+      >"$TMP/maven.txt" 2>&1 || true
+  )
+  section "backend-java (Maven dependency updates)" "$TMP/maven.txt"
+fi
+
+echo "_End of report._" >>"$OUT"
+echo "Wrote $OUT"

--- a/scripts/ci/upsert_automation_issue.sh
+++ b/scripts/ci/upsert_automation_issue.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Create or update a single open automation issue by exact title match.
+# Usage: upsert_automation_issue.sh <title> <body-file> [label...]
+set -euo pipefail
+
+TITLE="${1:?title required}"
+BODY_FILE="${2:?body file required}"
+shift 2
+
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "Body file not found: $BODY_FILE" >&2
+  exit 1
+fi
+
+ensure_label() {
+  local name="$1"
+  gh label create "$name" --color "0E8A16" --description "Automation" --force >/dev/null 2>&1 || true
+}
+
+LABELS=("$@")
+for label in "${LABELS[@]}"; do
+  ensure_label "$label"
+done
+
+EXISTING="$(
+  gh issue list --state open --limit 100 --json number,title \
+    | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+    | head -n 1
+)"
+
+if [[ -z "$EXISTING" ]]; then
+  EXISTING="$(
+    gh issue list --state open --search "${TITLE}" --limit 20 --json number,title \
+      | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+      | head -n 1
+  )"
+fi
+
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID:-unknown}"
+
+if [[ -n "$EXISTING" ]]; then
+  echo "Updating issue #${EXISTING}"
+  gh issue edit "$EXISTING" --body-file "$BODY_FILE"
+  if ((${#LABELS[@]})); then
+    ADD_ARGS=()
+    for label in "${LABELS[@]}"; do
+      ADD_ARGS+=(--add-label "$label")
+    done
+    gh issue edit "$EXISTING" "${ADD_ARGS[@]}" || true
+  fi
+  gh issue comment "$EXISTING" --body "Automated refresh from workflow run: ${RUN_URL}"
+  echo "ISSUE_NUMBER=${EXISTING}"
+else
+  echo "Creating issue: ${TITLE}"
+  CREATE_ARGS=(issue create --title "$TITLE" --body-file "$BODY_FILE")
+  for label in "${LABELS[@]}"; do
+    CREATE_ARGS+=(--label "$label")
+  done
+  URL="$(gh "${CREATE_ARGS[@]}")"
+  echo "Created ${URL}"
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds GitHub automation for dependency upgrades and periodic bug discovery, per the 1C + 2C request:

1. **Dependabot** (`.github/dependabot.yml`) — weekly PRs for npm (`frontend`), Maven (`backend-java`), pip (`backend`, `integrations/pydantic-ai`), and GitHub Actions.
2. **Outdated dependencies Issue** (`.github/workflows/outdated-deps.yml`) — weekly scan that upserts a single `[automation] Outdated dependencies` Issue (npm / uv / Maven).
3. **CodeQL** (`.github/workflows/codeql.yml`) — analyzes JS/TS, Python, and Java; on schedule, upserts `[automation] CodeQL open alerts` when alerts exist (closes it when clear).
4. **Scheduled CI Issues** — extends existing CI with a daily cron; failures upsert `[automation] Scheduled CI failure`, and a green run closes that Issue.

Shared helpers live under `scripts/ci/outdated_deps_report.sh` and `scripts/ci/upsert_automation_issue.sh`.

Also fixes `astral-sh/setup-uv` caching to key on `**/pyproject.toml` because `uv.lock` is gitignored (this was already failing on `main`).

## Notes
- Code scanning alerts still appear under **Security → Code scanning**; the Issue is a summary for triage.
- CodeQL on private repos needs GitHub Advanced Security (or a public repo).
- Workflows are also `workflow_dispatch`-able for manual runs.
- `backend-java` test failures related to multi-tenant auth / duplicate `AgentflowProperties` are pre-existing on `main` and are outside this PR’s scope; scheduled CI will correctly open Issues for them until fixed separately.

## Test plan
- [ ] Merge and confirm Dependabot appears under **Insights → Dependency graph → Dependabot**
- [ ] Manually run **Outdated dependencies** and confirm an Issue is created/updated
- [ ] Manually run **CodeQL** and confirm analysis completes (and Issue behavior matches alert count)
- [ ] Confirm `backend` job gets past `setup-uv` (no missing `uv.lock` cache error)
- [ ] Manually run **CI** via `workflow_dispatch` (or wait for schedule) and confirm failure/success Issue behavior

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02c71-f6e1-7a92-be5e-e33f84cf4e28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02c71-f6e1-7a92-be5e-e33f84cf4e28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

