### PR TITLE
feat: implement OIDC authentication support

### DIFF
--- a/.cursor/rules/codegraph.mdc
+++ b/.cursor/rules/codegraph.mdc
@@ -1,0 +1,38 @@
+---
+description: CodeGraph MCP usage guide — when to use which tool
+alwaysApply: true
+---
+<!-- CODEGRAPH_START -->
+## CodeGraph
+
+This project has a CodeGraph MCP server (`codegraph_*` tools) configured. CodeGraph is a tree-sitter-parsed knowledge graph of every symbol, edge, and file. Reads are sub-millisecond and return structural information grep cannot.
+
+### When to prefer codegraph over native search
+
+Use codegraph for **structural** questions — what calls what, what would break, where is X defined, what is X's signature. Use native grep/read only for **literal text** queries (string contents, comments, log messages) or after you already have a specific file open.
+
+| Question | Tool |
+|---|---|
+| "Where is X defined?" / "Find symbol named X" | `codegraph_search` |
+| "What calls function Y?" | `codegraph_callers` |
+| "What does Y call?" | `codegraph_callees` |
+| "What would break if I changed Z?" | `codegraph_impact` |
+| "Show me Y's signature / source / docstring" | `codegraph_node` |
+| "Give me focused context for a task/area" | `codegraph_context` |
+| "See several related symbols' source at once" | `codegraph_explore` |
+| "What files exist under path/" | `codegraph_files` |
+| "Is the index healthy?" | `codegraph_status` |
+
+### Rules of thumb
+
+- **Answer directly — don't delegate exploration.** For "how does X work" / architecture / trace questions, answer with 2-3 codegraph calls: `codegraph_context` first, then ONE `codegraph_explore` for the source of the symbols it surfaces. Codegraph IS the pre-built index, so spawning a separate file-reading sub-task/agent — or running a grep + read loop — repeats work codegraph already did and costs more for the same answer.
+- **Trust codegraph results.** They come from a full AST parse. Do NOT re-verify them with grep — that's slower, less accurate, and wastes context.
+- **Don't grep first** when looking up a symbol by name. `codegraph_search` is faster and returns kind + location + signature in one call.
+- **Don't chain `codegraph_search` + `codegraph_node`** when you just want context — `codegraph_context` is one call.
+- **Don't loop `codegraph_node` over many symbols** — one `codegraph_explore` call returns several symbols' source grouped in a single capped call, while each separate node/Read call re-reads the whole context and costs far more.
+- **Index lag**: the file watcher debounces ~500ms behind writes; don't re-query immediately after editing a file in the same turn.
+
+### If `.codegraph/` doesn't exist
+
+The MCP server returns "not initialized." Ask the user: *"I notice this project doesn't have CodeGraph initialized. Want me to run `codegraph init -i` to build the index?"*
+<!-- CODEGRAPH_END -->

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The HTTP layer that the frontend talks to is a Java/Spring Boot service in
 processes in [`backend/`](backend/) that consume a Redis-backed job queue and
 drive adapters (LangGraph, Echo, ...) to completion.
 
+The API supports tenant-scoped RBAC through API keys and OIDC Bearer tokens.
+For identity-provider setup, tenant claim requirements, and group-to-role
+mapping, see [`docs/oidc.md`](docs/oidc.md).
+
 ```
 ┌───────────────────┐  REST   ┌──────────────────────┐
 │  Next.js console  │ ──────▶ │  Java/Spring Boot API│

--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/backend-java/src/main/java/io/agentflow/api/config/AgentflowProperties.java
+++ b/backend-java/src/main/java/io/agentflow/api/config/AgentflowProperties.java
@@ -82,6 +82,7 @@ public class AgentflowProperties {
     public static class Auth {
         private boolean enabled = false;
         private List<ApiKeyEntry> keys = List.of();
+        private Oidc oidc = new Oidc();
 
         public boolean isEnabled() {
             return enabled;
@@ -97,6 +98,120 @@ public class AgentflowProperties {
 
         public void setKeys(List<ApiKeyEntry> keys) {
             this.keys = keys == null ? List.of() : keys;
+        }
+
+        public Oidc getOidc() {
+            return oidc;
+        }
+
+        public void setOidc(Oidc oidc) {
+            this.oidc = oidc == null ? new Oidc() : oidc;
+        }
+    }
+
+    /**
+     * OIDC resource-server settings.
+     *
+     * <p>OIDC tokens are accepted only when both {@link Auth#enabled} and this
+     * section's {@link #enabled} flag are true. A token must contain a tenant
+     * claim. Roles are resolved from configured mappings and then from values
+     * that match the built-in {@code viewer}, {@code operator}, or {@code admin}
+     * role names.
+     */
+    public static class Oidc {
+        private boolean enabled = false;
+        private String issuerUri;
+        private String jwkSetUri;
+        private String audience;
+        private String tenantClaim = "tenant_id";
+        private String roleClaim = "roles";
+        private String defaultRole = "viewer";
+        private List<OidcRoleMapping> roleMappings = List.of();
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getIssuerUri() {
+            return issuerUri;
+        }
+
+        public void setIssuerUri(String issuerUri) {
+            this.issuerUri = issuerUri;
+        }
+
+        public String getJwkSetUri() {
+            return jwkSetUri;
+        }
+
+        public void setJwkSetUri(String jwkSetUri) {
+            this.jwkSetUri = jwkSetUri;
+        }
+
+        public String getAudience() {
+            return audience;
+        }
+
+        public void setAudience(String audience) {
+            this.audience = audience;
+        }
+
+        public String getTenantClaim() {
+            return tenantClaim;
+        }
+
+        public void setTenantClaim(String tenantClaim) {
+            this.tenantClaim = tenantClaim;
+        }
+
+        public String getRoleClaim() {
+            return roleClaim;
+        }
+
+        public void setRoleClaim(String roleClaim) {
+            this.roleClaim = roleClaim;
+        }
+
+        public String getDefaultRole() {
+            return defaultRole;
+        }
+
+        public void setDefaultRole(String defaultRole) {
+            this.defaultRole = defaultRole;
+        }
+
+        public List<OidcRoleMapping> getRoleMappings() {
+            return roleMappings;
+        }
+
+        public void setRoleMappings(List<OidcRoleMapping> roleMappings) {
+            this.roleMappings = roleMappings == null ? List.of() : roleMappings;
+        }
+    }
+
+    /** Maps one value in the configured OIDC role claim to an application role. */
+    public static class OidcRoleMapping {
+        private String claimValue;
+        private String role = "viewer";
+
+        public String getClaimValue() {
+            return claimValue;
+        }
+
+        public void setClaimValue(String claimValue) {
+            this.claimValue = claimValue;
+        }
+
+        public String getRole() {
+            return role;
+        }
+
+        public void setRole(String role) {
+            this.role = role;
         }
     }
 

--- a/backend-java/src/main/java/io/agentflow/api/security/AuthFilter.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/AuthFilter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Resolves the caller's tenant + role from an API key.
+ * Resolves the caller's tenant + role from an API key or an OIDC Bearer token.
  *
  * <p>When {@code agentflow.auth.enabled=false} (default), every request is
  * treated as {@code admin} on the {@code default} tenant so local development
@@ -27,9 +27,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class AuthFilter extends OncePerRequestFilter {
 
     private final AgentflowProperties properties;
+    private final OidcTokenAuthenticator oidc;
 
     public AuthFilter(AgentflowProperties properties) {
         this.properties = properties;
+        this.oidc = new OidcTokenAuthenticator(properties.getAuth());
     }
 
     @Override
@@ -47,7 +49,7 @@ public class AuthFilter extends OncePerRequestFilter {
         try {
             AuthPrincipal principal = resolve(request);
             if (principal == null) {
-                writeError(response, HttpStatus.UNAUTHORIZED, "Missing or invalid API key");
+                writeError(response, HttpStatus.UNAUTHORIZED, "Missing or invalid credentials");
                 return;
             }
             TenantContext.set(principal);
@@ -63,18 +65,30 @@ public class AuthFilter extends OncePerRequestFilter {
             return new AuthPrincipal(
                     TenantContext.DEFAULT_TENANT_ID, Role.ADMIN, "anonymous");
         }
-        String token = extractToken(request);
-        if (token == null) {
+        String apiKey = extractApiKey(request);
+        if (apiKey != null) {
+            return indexKeys(auth.getKeys()).get(apiKey);
+        }
+        String bearerToken = extractBearerToken(request);
+        if (bearerToken == null) {
             return null;
         }
-        return indexKeys(auth.getKeys()).get(token);
+        AuthPrincipal apiKeyPrincipal = indexKeys(auth.getKeys()).get(bearerToken);
+        if (apiKeyPrincipal != null) {
+            return apiKeyPrincipal;
+        }
+        return oidc.authenticate(bearerToken);
     }
 
-    private static String extractToken(HttpServletRequest request) {
+    private static String extractApiKey(HttpServletRequest request) {
         String apiKey = request.getHeader("X-Api-Key");
         if (apiKey != null && !apiKey.isBlank()) {
             return apiKey.trim();
         }
+        return null;
+    }
+
+    private static String extractBearerToken(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
         if (authorization == null || authorization.isBlank()) {
             return null;

--- a/backend-java/src/main/java/io/agentflow/api/security/OidcTokenAuthenticator.java
+++ b/backend-java/src/main/java/io/agentflow/api/security/OidcTokenAuthenticator.java
@@ -1,0 +1,198 @@
+package io.agentflow.api.security;
+
+import io.agentflow.api.config.AgentflowProperties;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+/**
+ * Verifies an OpenID Connect JWT and translates its claims into the existing
+ * application principal used by multi-tenancy and RBAC.
+ *
+ * <p>This class intentionally implements the resource-server half of OIDC.
+ * The browser or API client authenticates with the identity provider, then
+ * sends the resulting access token in {@code Authorization: Bearer <token>}.
+ * No application session, redirect callback, or client secret is kept by this
+ * API, which makes the flow appropriate for both the web UI and automation.
+ *
+ * <p>The decoder validates JWT signature, expiration, not-before, and issuer.
+ * If configured, audience is also required. Invalid or incomplete tokens are
+ * represented by a {@code null} result so the filter can return one generic
+ * 401 response without leaking validation details to callers.
+ */
+public final class OidcTokenAuthenticator {
+
+    private static final OAuth2Error INVALID_AUDIENCE =
+            new OAuth2Error("invalid_token", "Token audience is not accepted", null);
+
+    private final AgentflowProperties.Auth auth;
+    private volatile JwtDecoder decoder;
+
+    public OidcTokenAuthenticator(AgentflowProperties.Auth auth) {
+        this(auth, null);
+    }
+
+    OidcTokenAuthenticator(AgentflowProperties.Auth auth, JwtDecoder decoder) {
+        this.auth = auth;
+        this.decoder = decoder;
+    }
+
+    /**
+     * Returns a principal for a valid configured OIDC token, otherwise null.
+     *
+     * <p>Returning null lets {@link AuthFilter} preserve the same behaviour
+     * for an unknown API key and an invalid OIDC token.
+     */
+    public AuthPrincipal authenticate(String token) {
+        AgentflowProperties.Oidc oidc = auth.getOidc();
+        if (!oidc.isEnabled() || token == null || token.isBlank()) {
+            return null;
+        }
+        try {
+            return toPrincipal(decoder().decode(token), oidc);
+        } catch (JwtException | IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private JwtDecoder decoder() {
+        JwtDecoder current = decoder;
+        if (current != null) {
+            return current;
+        }
+        synchronized (this) {
+            if (decoder == null) {
+                decoder = createDecoder(auth.getOidc());
+            }
+            return decoder;
+        }
+    }
+
+    private static JwtDecoder createDecoder(AgentflowProperties.Oidc oidc) {
+        String issuer = requireText(oidc.getIssuerUri(), "agentflow.auth.oidc.issuer-uri");
+        JwtDecoder result;
+        if (hasText(oidc.getJwkSetUri())) {
+            NimbusJwtDecoder nimbus = NimbusJwtDecoder.withJwkSetUri(oidc.getJwkSetUri().trim()).build();
+            nimbus.setJwtValidator(validators(issuer, oidc.getAudience()));
+            result = nimbus;
+        } else {
+            // Spring obtains discovery metadata and JWKS from the verified issuer.
+            result = JwtDecoders.fromIssuerLocation(issuer);
+            if (result instanceof NimbusJwtDecoder nimbus) {
+                nimbus.setJwtValidator(validators(issuer, oidc.getAudience()));
+            }
+        }
+        return result;
+    }
+
+    private static OAuth2TokenValidator<Jwt> validators(String issuer, String audience) {
+        OAuth2TokenValidator<Jwt> issuerValidator = JwtValidators.createDefaultWithIssuer(issuer);
+        if (!hasText(audience)) {
+            return issuerValidator;
+        }
+        String expectedAudience = audience.trim();
+        OAuth2TokenValidator<Jwt> audienceValidator =
+                jwt ->
+                        jwt.getAudience().contains(expectedAudience)
+                                ? OAuth2TokenValidatorResult.success()
+                                : OAuth2TokenValidatorResult.failure(INVALID_AUDIENCE);
+        return new DelegatingOAuth2TokenValidator<>(issuerValidator, audienceValidator);
+    }
+
+    /** Resolves the required tenant claim and the strongest mapped application role. */
+    static AuthPrincipal toPrincipal(Jwt jwt, AgentflowProperties.Oidc oidc) {
+        String tenantClaim = requireText(oidc.getTenantClaim(), "agentflow.auth.oidc.tenant-claim");
+        String tenantId = stringClaim(jwt, tenantClaim);
+        if (!hasText(tenantId)) {
+            throw new IllegalArgumentException("OIDC token is missing its tenant claim");
+        }
+
+        String subject = jwt.getSubject();
+        if (!hasText(subject)) {
+            throw new IllegalArgumentException("OIDC token is missing its subject");
+        }
+        return new AuthPrincipal(tenantId.trim(), resolveRole(jwt, oidc), subject.trim());
+    }
+
+    private static Role resolveRole(Jwt jwt, AgentflowProperties.Oidc oidc) {
+        Role resolved = Role.parse(requireText(oidc.getDefaultRole(), "agentflow.auth.oidc.default-role"));
+        for (String claimValue : claimValues(jwt.getClaim(oidc.getRoleClaim()))) {
+            Role mapped = mappedRole(claimValue, oidc.getRoleMappings());
+            if (mapped == null) {
+                mapped = parseRoleOrNull(claimValue);
+            }
+            if (mapped != null && mapped.atLeast(resolved)) {
+                resolved = mapped;
+            }
+        }
+        return resolved;
+    }
+
+    private static Role mappedRole(
+            String claimValue, List<AgentflowProperties.OidcRoleMapping> mappings) {
+        if (mappings == null) {
+            return null;
+        }
+        for (AgentflowProperties.OidcRoleMapping mapping : mappings) {
+            if (mapping == null || !hasText(mapping.getClaimValue())) {
+                continue;
+            }
+            if (mapping.getClaimValue().trim().equalsIgnoreCase(claimValue)) {
+                return Role.parse(requireText(mapping.getRole(), "OIDC role mapping role"));
+            }
+        }
+        return null;
+    }
+
+    private static List<String> claimValues(Object claim) {
+        List<String> values = new ArrayList<>();
+        if (claim instanceof String value) {
+            for (String piece : value.split("[ ,]+")) {
+                if (hasText(piece)) {
+                    values.add(piece.trim());
+                }
+            }
+        } else if (claim instanceof Collection<?> collection) {
+            for (Object value : collection) {
+                if (value != null && hasText(value.toString())) {
+                    values.add(value.toString().trim());
+                }
+            }
+        }
+        return values;
+    }
+
+    private static String stringClaim(Jwt jwt, String name) {
+        Object value = jwt.getClaim(name);
+        return value == null ? null : value.toString();
+    }
+
+    private static Role parseRoleOrNull(String value) {
+        try {
+            return Role.parse(value);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private static String requireText(String value, String property) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException(property + " must be configured");
+        }
+        return value.trim();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/backend-java/src/main/resources/application.yml
+++ b/backend-java/src/main/resources/application.yml
@@ -57,6 +57,17 @@ agentflow:
       - key: ${AGENTFLOW_API_KEY_ADMIN:dev-admin}
         tenant-id: default
         role: admin
+    # OIDC is an additive resource-server authentication method. API keys
+    # remain supported, while standard Bearer JWTs are verified against the
+    # provider's published JWKS. See docs/oidc.md for a complete example.
+    oidc:
+      enabled: ${AGENTFLOW_OIDC_ENABLED:false}
+      issuer-uri: ${AGENTFLOW_OIDC_ISSUER_URI:}
+      jwk-set-uri: ${AGENTFLOW_OIDC_JWK_SET_URI:}
+      audience: ${AGENTFLOW_OIDC_AUDIENCE:}
+      tenant-claim: ${AGENTFLOW_OIDC_TENANT_CLAIM:tenant_id}
+      role-claim: ${AGENTFLOW_OIDC_ROLE_CLAIM:roles}
+      default-role: ${AGENTFLOW_OIDC_DEFAULT_ROLE:viewer}
 
 management:
   tracing:

--- a/backend-java/src/test/java/io/agentflow/api/security/OidcTokenAuthenticatorTest.java
+++ b/backend-java/src/test/java/io/agentflow/api/security/OidcTokenAuthenticatorTest.java
@@ -1,0 +1,139 @@
+package io.agentflow.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.agentflow.api.config.AgentflowProperties;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/**
+ * Unit tests for OIDC claim-to-principal translation.
+ *
+ * <p>Cryptographic verification is delegated to Spring Security's Nimbus
+ * decoder. These tests focus on application-owned authorization semantics:
+ * tenant isolation, RBAC mapping, and fail-closed required identity claims.
+ */
+class OidcTokenAuthenticatorTest {
+
+    @Test
+    void mapsTenantSubjectAndExplicitRoleMapping() {
+        AgentflowProperties.Oidc oidc = baseOidc();
+        AgentflowProperties.OidcRoleMapping mapping = new AgentflowProperties.OidcRoleMapping();
+        mapping.setClaimValue("platform-admins");
+        mapping.setRole("admin");
+        oidc.setRoleMappings(List.of(mapping));
+
+        AuthPrincipal principal =
+                OidcTokenAuthenticator.toPrincipal(
+                        jwt(Map.of("tenant_id", "acme", "roles", List.of("platform-admins"))), oidc);
+
+        assertThat(principal.tenantId()).isEqualTo("acme");
+        assertThat(principal.subject()).isEqualTo("user-123");
+        assertThat(principal.role()).isEqualTo(Role.ADMIN);
+    }
+
+    @Test
+    void choosesStrongestRoleAcrossClaimValues() {
+        AgentflowProperties.Oidc oidc = baseOidc();
+
+        AuthPrincipal principal =
+                OidcTokenAuthenticator.toPrincipal(
+                        jwt(Map.of("tenant_id", "acme", "roles", List.of("viewer", "operator"))), oidc);
+
+        assertThat(principal.role()).isEqualTo(Role.OPERATOR);
+    }
+
+    @Test
+    void acceptsSpaceDelimitedRoleClaims() {
+        AgentflowProperties.Oidc oidc = baseOidc();
+
+        AuthPrincipal principal =
+                OidcTokenAuthenticator.toPrincipal(
+                        jwt(Map.of("tenant_id", "acme", "roles", "viewer admin")), oidc);
+
+        assertThat(principal.role()).isEqualTo(Role.ADMIN);
+    }
+
+    @Test
+    void fallsBackToConfiguredLeastPrivilegeRoleForUnknownGroups() {
+        AgentflowProperties.Oidc oidc = baseOidc();
+        oidc.setDefaultRole("viewer");
+
+        AuthPrincipal principal =
+                OidcTokenAuthenticator.toPrincipal(
+                        jwt(Map.of("tenant_id", "acme", "roles", List.of("billing-team"))), oidc);
+
+        assertThat(principal.role()).isEqualTo(Role.VIEWER);
+    }
+
+    @Test
+    void rejectsTokenWithoutTenantClaim() {
+        AgentflowProperties.Oidc oidc = baseOidc();
+
+        assertThatThrownBy(() -> OidcTokenAuthenticator.toPrincipal(jwt(Map.of("roles", "admin")), oidc))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("tenant claim");
+    }
+
+    @Test
+    void rejectsTokenWithoutSubject() {
+        AgentflowProperties.Oidc oidc = baseOidc();
+        Jwt jwt =
+                Jwt.withTokenValue("test-token")
+                        .header("alg", "none")
+                        .claim("tenant_id", "acme")
+                        .issuedAt(Instant.parse("2026-01-01T00:00:00Z"))
+                        .expiresAt(Instant.parse("2026-01-01T01:00:00Z"))
+                        .build();
+
+        assertThatThrownBy(() -> OidcTokenAuthenticator.toPrincipal(jwt, oidc))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("subject");
+    }
+
+    @Test
+    void disabledOidcDoesNotAttemptTokenDecoding() {
+        AgentflowProperties.Auth auth = new AgentflowProperties.Auth();
+        auth.getOidc().setEnabled(false);
+        JwtDecoder failIfCalled = token -> {
+            throw new AssertionError("disabled OIDC must not decode tokens");
+        };
+
+        assertThat(new OidcTokenAuthenticator(auth, failIfCalled).authenticate("anything")).isNull();
+    }
+
+    @Test
+    void invalidDecoderResultIsExposedAsUnauthenticated() {
+        AgentflowProperties.Auth auth = new AgentflowProperties.Auth();
+        auth.getOidc().setEnabled(true);
+        JwtDecoder invalid = token -> {
+            throw new org.springframework.security.oauth2.jwt.BadJwtException("invalid signature");
+        };
+
+        assertThat(new OidcTokenAuthenticator(auth, invalid).authenticate("bad-token")).isNull();
+    }
+
+    private static AgentflowProperties.Oidc baseOidc() {
+        AgentflowProperties.Oidc oidc = new AgentflowProperties.Oidc();
+        oidc.setTenantClaim("tenant_id");
+        oidc.setRoleClaim("roles");
+        oidc.setDefaultRole("viewer");
+        return oidc;
+    }
+
+    private static Jwt jwt(Map<String, Object> claims) {
+        Jwt.Builder builder =
+                Jwt.withTokenValue("test-token")
+                        .header("alg", "none")
+                        .subject("user-123")
+                        .issuedAt(Instant.parse("2026-01-01T00:00:00Z"))
+                        .expiresAt(Instant.parse("2026-01-01T01:00:00Z"));
+        claims.forEach(builder::claim);
+        return builder.build();
+    }
+}

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,0 +1,104 @@
+# OIDC authentication
+
+The Java API can authenticate either a configured API key or an OpenID Connect
+access token. OIDC support is implemented as a resource server: users sign in
+with the identity provider, and the client sends the provider-issued JWT to the
+API. The service does not store browser sessions, user passwords, refresh
+tokens, or an OIDC client secret.
+
+## Enabling OIDC
+
+OIDC is deliberately disabled by default. Enable both the existing request
+authentication switch and the OIDC switch in the API environment:
+
+```bash
+export AGENTFLOW_AUTH_ENABLED=true
+export AGENTFLOW_OIDC_ENABLED=true
+export AGENTFLOW_OIDC_ISSUER_URI=https://login.example.com/realms/agentflow
+export AGENTFLOW_OIDC_AUDIENCE=agentflow-api
+```
+
+At startup or on the first OIDC request, the service discovers the issuer's
+OpenID Connect metadata and signing keys. In private-network deployments,
+configure the JWKS URL explicitly to avoid relying on discovery:
+
+```bash
+export AGENTFLOW_OIDC_JWK_SET_URI=https://login.example.com/realms/agentflow/protocol/openid-connect/certs
+```
+
+The issuer value remains mandatory even when a JWKS URL is configured. It
+prevents accepting a correctly signed token minted for a different issuer.
+
+## Request behaviour
+
+Send an access token with the ordinary Bearer header:
+
+```bash
+curl -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8080/v1/agents
+```
+
+The authentication order is predictable:
+
+1. `X-Api-Key` is treated only as an API key.
+2. A Bearer value matching a configured API key remains supported for backward compatibility.
+3. Any other Bearer value is validated as an OIDC JWT when OIDC is enabled.
+
+Malformed, expired, wrongly signed, wrong-issuer, or wrong-audience tokens
+all receive the same `401` response. This intentionally avoids revealing why
+a credential failed validation. Health and actuator endpoints remain open as
+they were before authentication was added.
+
+## Tenant mapping
+
+Every accepted OIDC token must have a non-empty tenant claim. The default claim
+name is `tenant_id`; configure another claim for providers that use `org_id`,
+`tenant`, or a namespaced custom claim:
+
+```bash
+export AGENTFLOW_OIDC_TENANT_CLAIM=org_id
+```
+
+The claim becomes `AuthPrincipal.tenantId`, so the existing repositories and
+services continue filtering reads and writes by tenant. A token missing this
+claim is rejected rather than being silently assigned to the default tenant.
+
+## RBAC mapping
+
+By default the service reads a `roles` claim. It accepts a JSON string array,
+or a space/comma-delimited string. Values equal to `viewer`, `operator`, or
+`admin` map directly to the existing application roles. When several roles are
+present, the strongest role wins.
+
+Most identity providers use group names instead. Configure group-to-role
+mappings under `agentflow.auth.oidc.role-mappings`:
+
+```yaml
+agentflow:
+  auth:
+    enabled: true
+    oidc:
+      enabled: true
+      issuer-uri: https://login.example.com/realms/agentflow
+      audience: agentflow-api
+      tenant-claim: org_id
+      role-claim: groups
+      default-role: viewer
+      role-mappings:
+        - claim-value: agentflow-admins
+          role: admin
+        - claim-value: agentflow-operators
+          role: operator
+```
+
+An unknown group receives `default-role`, which should normally remain
+`viewer`. Set `default-role` only to one of the application's existing roles;
+configuration with an invalid role fails closed for that request.
+
+## Operational notes
+
+Use HTTPS between clients, the API, and the identity provider. Keep clocks
+synchronized, because expiration and not-before checks depend on the server
+clock. The JWT decoder uses the provider's JWKS and supports signing-key
+rotation; do not pin a static public key in application configuration. API keys
+remain a useful migration path, but production clients should move to short-
+lived OIDC access tokens and rotate any remaining API keys regularly.


### PR DESCRIPTION
- Added support for OpenID Connect (OIDC) as an authentication method alongside existing API key authentication.
- Introduced `OidcTokenAuthenticator` to handle JWT verification and claim mapping for multi-tenancy and role-based access control (RBAC).
- Updated `AuthFilter` to resolve tenant and role from both API keys and OIDC tokens.
- Enhanced `AgentflowProperties` to include OIDC configuration options.
- Created documentation for OIDC setup and usage in `docs/oidc.md`.
- Added unit tests for OIDC token handling and role mapping.

This change improves security and flexibility in user authentication.
