### PR TITLE
feat(autogen): add official AutoGen adapter for AgentFlow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,6 +128,13 @@ toolsets. One PydanticAI run maps to one runtime step; token deltas, output,
 provider usage/cost, and tool events are translated to standard adapter events.
 The MVP does not rebuild Agents from JSON or implement checkpoint/resume.
 
+The official AutoGen integration lives in `integrations/autogen` and registers
+the `autogen` entry point. A trusted `agent_factory` or `team_factory` returns
+an AutoGen AgentChat agent or team. Single-agent runs map to one step; team
+runs can emit one step per agent turn. Token deltas, messages, native tool
+events, and AgentFlow-managed tools (via `AdapterToolSurface`) are translated
+to the same adapter contract.
+
 ## MCP tool bridge
 
 MCP (Model Context Protocol) tools are wired through a shared bridge so every

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -46,7 +46,7 @@
 **目标：** 第三方框架与工具可插拔，无需 fork runtime。
 
 - [x] Adapter 插件注册表（entry points / 动态加载）
-- [ ] 官方 adapter：AutoGen、CrewAI、PydanticAI（按需求选 2 个）
+- [x] 官方 adapter：AutoGen、CrewAI、PydanticAI（按需求选 2 个；已完成 AutoGen + PydanticAI）
 - [x] MCP tool adapter
 - [ ] OpenAPI 规范 + Python/TypeScript SDK 自动生成
 - [ ] Webhook 出站事件（`run.completed` 等）

--- a/integrations/autogen/README.md
+++ b/integrations/autogen/README.md
@@ -1,0 +1,103 @@
+# AgentFlow AutoGen adapter
+
+This optional plugin runs an existing AutoGen AgentChat agent or team and
+translates its stream, usage, and tool events to AgentFlow's shared runtime
+contract.
+
+## Install
+
+Install the backend and plugin in every Python worker, then restart the worker
+so entry-point discovery runs again:
+
+```bash
+pip install agentflow agentflow-autogen
+```
+
+From this repository:
+
+```bash
+pip install -e ./backend -e ./integrations/autogen
+```
+
+The package registers `autogen` in the `agentflow.adapters` entry-point group.
+It does not add AutoGen to AgentFlow's core dependencies.
+
+## Define the agent or team
+
+Expose a zero-argument factory from code installed in the worker environment:
+
+```python
+from autogen_agentchat.agents import AssistantAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+
+def create_agent(*, agentflow_tools=None) -> AssistantAgent:
+  tools = list(agentflow_tools or [])
+  return AssistantAgent(
+      name="assistant",
+      model_client=OpenAIChatCompletionClient(model="gpt-4o-mini"),
+      tools=tools,
+      model_client_stream=True,
+  )
+```
+
+For multi-agent runs, return a team with `run_stream()`:
+
+```python
+from autogen_agentchat.teams import RoundRobinGroupChat
+
+
+def create_team() -> RoundRobinGroupChat:
+  writer = create_agent()
+  editor = create_agent()
+  return RoundRobinGroupChat([writer, editor], max_turns=4)
+```
+
+The factory owns the AutoGen model client, instructions, native tools, and team
+topology. Returning a fresh agent or team per run avoids accidental state
+sharing between runs.
+
+## AgentFlow config
+
+Single agent:
+
+```json
+{
+  "adapter": "autogen",
+  "config": {
+    "agent_factory": "myapp.agents:create_agent",
+    "stream_tokens": true,
+    "tools": ["echo"]
+  }
+}
+```
+
+Team:
+
+```json
+{
+  "adapter": "autogen",
+  "config": {
+    "team_factory": "myapp.agents:create_team",
+    "per_turn_steps": true
+  }
+}
+```
+
+`tools`, `mcp_servers`, and `mcp_auto_register` use the same format as other
+AgentFlow adapters. When configured, the adapter exposes resolved tools to
+AutoGen for the current run and delegates their execution back to
+`AdapterToolSurface`. Factories may accept an optional `agentflow_tools`
+keyword to merge bridged tools explicitly.
+
+`agent_factory` / `team_factory` import and execute trusted Python code in the
+worker process. Only administrators should be allowed to configure them; this
+plugin is not a sandbox.
+
+One single-agent run maps to one AgentFlow step. Team runs can emit one step per
+agent turn when `per_turn_steps` is enabled (default for teams). The plugin
+emits user and assistant messages, token deltas, provider usage when available,
+and AgentFlow-owned ToolCall IDs for native AutoGen tool events.
+
+The plugin deliberately does not rebuild agents from JSON or implement
+checkpoint/retry or human-in-the-loop. AutoGen AgentChat 0.4.x is supported.

--- a/integrations/autogen/pyproject.toml
+++ b/integrations/autogen/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "agentflow-autogen"
+version = "0.1.0"
+description = "Official AutoGen adapter plugin for AgentFlow"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "Apache-2.0" }
+dependencies = [
+    "agentflow>=0.1.0,<0.2.0",
+    "autogen-agentchat>=0.4,<0.5",
+    "autogen-ext>=0.4,<0.5",
+]
+
+[project.entry-points."agentflow.adapters"]
+autogen = "agentflow_autogen:create_adapter"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.7",
+    "mypy>=1.13",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentflow_autogen"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "ASYNC", "RUF"]
+ignore = ["E501", "RUF002", "RUF003"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = false
+ignore_missing_imports = true
+disable_error_code = ["import-untyped"]

--- a/integrations/autogen/src/agentflow_autogen/__init__.py
+++ b/integrations/autogen/src/agentflow_autogen/__init__.py
@@ -1,0 +1,10 @@
+"""Official AutoGen adapter plugin for AgentFlow."""
+
+from agentflow_autogen.adapter import AutoGenAdapter
+
+__all__ = ["AutoGenAdapter", "create_adapter"]
+
+
+def create_adapter() -> AutoGenAdapter:
+    """Entry-point factory discovered through ``agentflow.adapters``."""
+    return AutoGenAdapter()

--- a/integrations/autogen/src/agentflow_autogen/adapter.py
+++ b/integrations/autogen/src/agentflow_autogen/adapter.py
@@ -1,0 +1,392 @@
+"""Run an existing AutoGen agent or team on AgentFlow's adapter surface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from contextlib import AsyncExitStack
+from importlib import import_module
+from inspect import signature
+from typing import Any
+
+from app.adapters.adapter_tools import open_tool_surface
+from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
+from app.core.logging import get_logger
+from app.models.run import RunStatus
+from autogen_agentchat.base import TaskResult
+from autogen_agentchat.messages import (
+    BaseChatMessage,
+    ModelClientStreamingChunkEvent,
+    TextMessage,
+    ToolCallExecutionEvent,
+    ToolCallRequestEvent,
+)
+
+from agentflow_autogen.tools import (
+    build_function_tools,
+    inject_tools,
+)
+
+logger = get_logger("adapter.autogen")
+
+DEFAULT_NODE = "autogen"
+USER_SOURCE = "user"
+
+
+class AutoGenAdapter(OrchestratorAdapter):
+    """Load a trusted AutoGen agent/team factory and translate one run."""
+
+    name = "autogen"
+
+    async def run(self, ctx: AdapterContext) -> AdapterResult:
+        config = ctx.agent_config
+        default_node = str(config.get("node") or DEFAULT_NODE)
+        prompt = prompt_from_input(ctx.input)
+        team_mode = bool(config.get("team_factory"))
+        per_turn_steps = bool(config.get("per_turn_steps", team_mode))
+        stream_tokens = bool(config.get("stream_tokens", True))
+        defer_initial_step = team_mode and per_turn_steps
+
+        handler = _StreamHandler(
+            ctx=ctx,
+            default_node=default_node,
+            per_turn_steps=per_turn_steps,
+            stream_tokens=stream_tokens,
+            step_index_base=ctx.step_index_base,
+        )
+        bridged_failure: list[str] = []
+
+        try:
+            async with AsyncExitStack() as stack:
+                bridged_names: frozenset[str] = frozenset()
+                if uses_agentflow_tools(config):
+                    surface = await stack.enter_async_context(open_tool_surface(config))
+                    if surface.tools:
+                        if not defer_initial_step:
+                            await handler.begin_step(default_node)
+                        bridged_tools, bridged_names = build_function_tools(
+                            surface,
+                            ctx,
+                            step_index=handler.current_step_index,
+                            on_tool_error=bridged_failure.append,
+                        )
+                    else:
+                        bridged_tools = []
+                else:
+                    bridged_tools = []
+
+                runnable = load_runnable(config, bridged_tools=bridged_tools)
+                maybe_enable_streaming(runnable, stream_tokens)
+
+                if not handler.step_started and not defer_initial_step:
+                    await handler.begin_step(default_node)
+
+                await handler.emit_user_prompt(prompt)
+                async for event in runnable.run_stream(task=prompt):
+                    await handler.handle(event, bridged_names=bridged_names)
+
+                if bridged_failure:
+                    raise RuntimeError(bridged_failure[0])
+
+                if handler.step_started and not handler.step_completed:
+                    await handler.complete_step(output=handler.final_output())
+
+            return AdapterResult(
+                status=RunStatus.SUCCEEDED,
+                output=handler.run_output(),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception("autogen_run_failed", run_id=ctx.run_id)
+            error = str(exc) or type(exc).__name__
+            await handler.fail_step(error)
+            return AdapterResult(status=RunStatus.FAILED, error=error)
+
+
+class _StreamHandler:
+    """Translate AutoGen stream events into AgentFlow adapter events."""
+
+    def __init__(
+        self,
+        *,
+        ctx: AdapterContext,
+        default_node: str,
+        per_turn_steps: bool,
+        stream_tokens: bool,
+        step_index_base: int,
+    ) -> None:
+        self.ctx = ctx
+        self.default_node = default_node
+        self.per_turn_steps = per_turn_steps
+        self.stream_tokens = stream_tokens
+        self._next_step_index = step_index_base
+        self._current_step_index = step_index_base
+        self._current_node = default_node
+        self.step_started = False
+        self.step_completed = False
+        self._started_at = 0.0
+        self._tokens_in = 0
+        self._tokens_out = 0
+        self._final_reply = ""
+        self._replies: list[str] = []
+        self._active_tool_calls: dict[str, tuple[str, str, float]] = {}
+        self._pending_user_prompt: str | None = None
+
+    @property
+    def current_step_index(self) -> int:
+        return self._current_step_index
+
+    async def begin_step(self, node: str) -> None:
+        if self.step_started and not self.step_completed:
+            return
+        self._current_node = node
+        self._current_step_index = self._next_step_index
+        self._next_step_index += 1
+        self.step_started = True
+        self.step_completed = False
+        self._started_at = time.monotonic()
+        self._tokens_in = 0
+        self._tokens_out = 0
+        await self.ctx.emit_step_started(index=self._current_step_index, node=self._current_node)
+
+    async def emit_user_prompt(self, prompt: str) -> None:
+        self._pending_user_prompt = prompt
+        await self.ctx.emit_message(role="user", content=prompt)
+
+    async def handle(self, event: Any, *, bridged_names: frozenset[str]) -> None:
+        if isinstance(event, ModelClientStreamingChunkEvent):
+            if self.stream_tokens and isinstance(event.content, str):
+                await self.ctx.emit_token_delta(
+                    step_index=self._current_step_index,
+                    delta=event.content,
+                )
+            return
+
+        if isinstance(event, TextMessage):
+            await self._handle_text_message(event)
+            return
+
+        if isinstance(event, ToolCallRequestEvent):
+            await self._handle_tool_request(event, bridged_names=bridged_names)
+            return
+
+        if isinstance(event, ToolCallExecutionEvent):
+            await self._handle_tool_execution(event, bridged_names=bridged_names)
+            return
+
+        if isinstance(event, TaskResult):
+            await self._handle_task_result(event)
+
+    async def _handle_text_message(self, message: TextMessage) -> None:
+        if message.source == USER_SOURCE:
+            content = str(message.content or "")
+            if self._pending_user_prompt is not None and content == self._pending_user_prompt:
+                self._pending_user_prompt = None
+                return
+            await self.ctx.emit_message(role="user", content=content, name=message.source)
+            return
+
+        if self.per_turn_steps:
+            if self.step_started and not self.step_completed:
+                await self.complete_step(output={"reply": self._final_reply})
+            await self.begin_step(str(message.source or self.default_node))
+
+        if not self.step_started:
+            await self.begin_step(str(message.source or self.default_node))
+
+        self._accumulate_usage(message)
+        content = str(message.content or "")
+        if content:
+            self._final_reply = content
+            self._replies.append(content)
+            await self.ctx.emit_message(
+                role="assistant",
+                content=content,
+                name=message.source,
+            )
+
+    async def _handle_tool_request(
+        self,
+        event: ToolCallRequestEvent,
+        *,
+        bridged_names: frozenset[str],
+    ) -> None:
+        self._accumulate_usage(event)
+        for call in event.content:
+            if call.name in bridged_names:
+                continue
+            arguments = _parse_tool_arguments(call.arguments)
+            call_id = await self.ctx.emit_tool_call_started(
+                step_index=self._current_step_index,
+                name=call.name,
+                arguments=arguments,
+            )
+            self._active_tool_calls[call.id] = (call.name, call_id, time.monotonic())
+
+    async def _handle_tool_execution(
+        self,
+        event: ToolCallExecutionEvent,
+        *,
+        bridged_names: frozenset[str],
+    ) -> None:
+        for result in event.content:
+            if result.name in bridged_names:
+                continue
+            active = self._active_tool_calls.pop(result.call_id, None)
+            if active is None:
+                call_id = await self.ctx.emit_tool_call_started(
+                    step_index=self._current_step_index,
+                    name=result.name,
+                    arguments={},
+                )
+                started = time.monotonic()
+            else:
+                _, call_id, started = active
+            payload = {"result": result.content}
+            await self.ctx.emit_tool_call_completed(
+                step_index=self._current_step_index,
+                name=result.name,
+                call_id=call_id,
+                result=payload,
+                error=str(result.content) if result.is_error else None,
+                latency_ms=int((time.monotonic() - started) * 1000),
+            )
+
+    async def _handle_task_result(self, result: TaskResult) -> None:
+        for message in result.messages:
+            if isinstance(message, TextMessage) and message.source != USER_SOURCE:
+                self._accumulate_usage(message)
+                content = str(message.content or "")
+                if content:
+                    self._final_reply = content
+                    if content not in self._replies:
+                        self._replies.append(content)
+
+    def _accumulate_usage(self, message: Any) -> None:
+        usage = getattr(message, "models_usage", None)
+        if usage is None:
+            return
+        self._tokens_in += int(getattr(usage, "prompt_tokens", 0) or 0)
+        self._tokens_out += int(getattr(usage, "completion_tokens", 0) or 0)
+
+    async def complete_step(self, *, output: dict[str, Any]) -> None:
+        if not self.step_started or self.step_completed:
+            return
+        latency_ms = int((time.monotonic() - self._started_at) * 1000)
+        metrics: dict[str, Any] = {
+            "tokens_in": self._tokens_in,
+            "tokens_out": self._tokens_out,
+            "latency_ms": latency_ms,
+        }
+        await self.ctx.emit_step_updated(index=self._current_step_index, **metrics)
+        await self.ctx.emit_step_completed(
+            index=self._current_step_index,
+            node=self._current_node,
+            output=output,
+            **metrics,
+        )
+        self.step_completed = True
+
+    async def fail_step(self, error: str) -> None:
+        if not self.step_started:
+            await self.ctx.emit_step_started(index=self._current_step_index, node=self._current_node)
+        await self._close_active_tools(error)
+        await self.ctx.emit_step_failed(
+            index=self._current_step_index,
+            node=self._current_node,
+            error=error,
+        )
+
+    async def _close_active_tools(self, error: str) -> None:
+        for name, call_id, started in self._active_tool_calls.values():
+            await self.ctx.emit_tool_call_completed(
+                step_index=self._current_step_index,
+                name=name,
+                call_id=call_id,
+                error=error,
+                latency_ms=int((time.monotonic() - started) * 1000),
+            )
+        self._active_tool_calls.clear()
+
+    def final_output(self) -> dict[str, Any]:
+        reply = self._final_reply or (self._replies[-1] if self._replies else "")
+        output: dict[str, Any] = {"reply": reply}
+        if len(self._replies) > 1:
+            output["replies"] = list(self._replies)
+        return output
+
+    def run_output(self) -> dict[str, Any]:
+        return self.final_output()
+
+
+def uses_agentflow_tools(config: dict[str, Any]) -> bool:
+    return bool(config.get("tools") or config.get("mcp_auto_register"))
+
+
+def load_runnable(config: dict[str, Any], *, bridged_tools: list[Any]) -> Any:
+    """Load an AutoGen agent or team from trusted worker code."""
+    if config.get("team_factory"):
+        runnable = _load_factory(config["team_factory"], bridged_tools=bridged_tools)
+        if not hasattr(runnable, "run_stream"):
+            raise TypeError("team_factory must return an object with run_stream()")
+        return runnable
+
+    if config.get("agent_factory"):
+        agent = _load_factory(config["agent_factory"], bridged_tools=bridged_tools)
+        if not hasattr(agent, "run_stream"):
+            raise TypeError("agent_factory must return an object with run_stream()")
+        return inject_tools(agent, bridged_tools)
+
+    raise ValueError("agent_factory or team_factory must be configured")
+
+
+def _load_factory(reference: Any, *, bridged_tools: list[Any]) -> Any:
+    if not isinstance(reference, str) or not reference.strip():
+        raise ValueError("factory must be a non-empty 'module:factory' string")
+
+    module_name, separator, factory_name = reference.strip().partition(":")
+    if not separator or not module_name or not factory_name:
+        raise ValueError("factory must use the 'module:factory' format")
+
+    factory = getattr(import_module(module_name), factory_name, None)
+    if not callable(factory):
+        raise TypeError(f"factory {reference!r} is not callable")
+
+    kwargs: dict[str, Any] = {}
+    params = signature(factory).parameters
+    if bridged_tools and "agentflow_tools" in params:
+        kwargs["agentflow_tools"] = bridged_tools
+
+    return factory(**kwargs)
+
+
+def maybe_enable_streaming(runnable: Any, stream_tokens: bool) -> None:
+    if not stream_tokens:
+        return
+    stream_attr = getattr(runnable, "_model_client_stream", None)
+    if isinstance(stream_attr, bool):
+        runnable._model_client_stream = True
+
+
+def prompt_from_input(run_input: dict[str, Any]) -> str:
+    for key in ("prompt", "message", "text", "input", "task"):
+        if key in run_input:
+            value = run_input[key]
+            return value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+    return json.dumps(run_input, ensure_ascii=False)
+
+
+def _parse_tool_arguments(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        if not raw.strip():
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"raw": raw}
+        return parsed if isinstance(parsed, dict) else {"value": parsed}
+    return {"value": raw}

--- a/integrations/autogen/src/agentflow_autogen/tools.py
+++ b/integrations/autogen/src/agentflow_autogen/tools.py
@@ -1,0 +1,117 @@
+"""Bridge AgentFlow-managed tools into AutoGen ``FunctionTool`` instances."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any, Callable
+
+from app.adapters.adapter_tools import AdapterToolSurface
+from app.adapters.base import AdapterContext
+from app.adapters.tool_registry import ToolDefinition
+from autogen_core.tools import FunctionTool
+
+
+def build_function_tools(
+    surface: AdapterToolSurface,
+    ctx: AdapterContext,
+    *,
+    step_index: int,
+    on_tool_error: Callable[[str], None] | None = None,
+) -> tuple[list[FunctionTool], frozenset[str]]:
+    """Create AutoGen tools that delegate execution to ``AdapterToolSurface``."""
+    tools: list[FunctionTool] = []
+    names: set[str] = set()
+
+    for definition in surface.tools:
+        handler = _make_handler(
+            surface,
+            ctx,
+            step_index=step_index,
+            definition=definition,
+            on_tool_error=on_tool_error,
+        )
+        tools.append(
+            FunctionTool(
+                handler,
+                description=definition.description or f"Invoke the {definition.name} tool.",
+                name=definition.name,
+            )
+        )
+        names.add(definition.name)
+
+    return tools, frozenset(names)
+
+
+def _make_handler(
+    surface: AdapterToolSurface,
+    ctx: AdapterContext,
+    *,
+    step_index: int,
+    definition: ToolDefinition,
+    on_tool_error: Callable[[str], None] | None = None,
+):
+    properties = (definition.parameters or {}).get("properties") or {}
+
+    async def _execute(arguments: dict[str, Any]) -> str:
+        try:
+            result = await surface.execute(
+                ctx,
+                step_index=step_index,
+                name=definition.name,
+                arguments=arguments,
+            )
+            return _stringify_result(result)
+        except Exception as exc:
+            if on_tool_error is not None:
+                on_tool_error(str(exc) or type(exc).__name__)
+            return str(exc) or type(exc).__name__
+
+    if not properties:
+        async def handler() -> str:
+            return await _execute({})
+
+        handler.__name__ = definition.name
+        return handler
+
+    if set(properties) == {"text"}:
+        async def handler(text: Annotated[str, "Tool input text."] = "") -> str:
+            return await _execute({"text": text})
+
+        handler.__name__ = definition.name
+        return handler
+
+    async def handler(input_json: Annotated[str, "JSON-encoded tool arguments."] = "{}") -> str:
+        try:
+            parsed = json.loads(input_json or "{}")
+        except json.JSONDecodeError:
+            parsed = {"raw": input_json}
+        arguments = parsed if isinstance(parsed, dict) else {"value": parsed}
+        return await _execute(arguments)
+
+    handler.__name__ = definition.name
+    return handler
+
+
+def _stringify_result(result: dict[str, Any]) -> str:
+    if not result:
+        return ""
+    if len(result) == 1 and "result" in result:
+        value = result["result"]
+        return value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+    return json.dumps(result, ensure_ascii=False)
+
+
+def inject_tools(runnable: Any, extra_tools: list[FunctionTool]) -> Any:
+    """Attach bridged tools to an AutoGen agent when possible."""
+    if not extra_tools:
+        return runnable
+
+    tools_attr = getattr(runnable, "_tools", None)
+    if isinstance(tools_attr, list):
+        existing_names = {getattr(tool, "name", None) for tool in tools_attr}
+        for tool in extra_tools:
+            if tool.name not in existing_names:
+                tools_attr.append(tool)
+        return runnable
+
+    return runnable

--- a/integrations/autogen/tests/test_adapter.py
+++ b/integrations/autogen/tests/test_adapter.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from app.adapters.base import AdapterContext
+from app.adapters.tool_registry import register_tool
+from app.models.run import RunStatus
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.base import TaskResult
+from autogen_agentchat.messages import TextMessage
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_core._types import FunctionCall
+from autogen_core.models import CreateResult, ModelInfo, RequestUsage
+from autogen_ext.models.replay import ReplayChatCompletionClient
+
+from agentflow_autogen import AutoGenAdapter, create_adapter
+
+
+class RecordingContext(AdapterContext):
+    def __init__(self, config: dict[str, Any], *, prompt: str = "hello") -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+        super().__init__(
+            run_id="01AUTOGEN",
+            agent_id="01AGENT",
+            agent_config=config,
+            input={"prompt": prompt},
+            emit=self._emit,
+        )
+
+    async def _emit(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+
+    def event(self, event_type: str) -> list[dict[str, Any]]:
+        return [data for current, data in self.events if current == event_type]
+
+
+def factory_reference(name: str) -> str:
+    return f"{__name__}:{name}"
+
+
+def text_agent(*, agentflow_tools=None) -> AssistantAgent:
+    client = ReplayChatCompletionClient(
+        ["Hello from AutoGen"],
+        model_info=ModelInfo(
+            vision=False,
+            function_calling=True,
+            json_output=False,
+            family="unknown",
+        ),
+    )
+    tools = list(agentflow_tools or [])
+    return AssistantAgent(
+        name="assistant",
+        model_client=client,
+        tools=tools,
+        model_client_stream=True,
+    )
+
+
+def tool_agent(*, agentflow_tools=None) -> AssistantAgent:
+    async def echo(text: str) -> str:
+        return f"echo:{text}"
+
+    usage = RequestUsage(prompt_tokens=5, completion_tokens=2)
+    call = FunctionCall(id="provider-call-id", name="echo", arguments=json.dumps({"text": "ping"}))
+    responses = [
+        CreateResult(content=[call], finish_reason="function_calls", usage=usage, cached=False),
+        CreateResult(content="done", finish_reason="stop", usage=usage, cached=False),
+    ]
+    client = ReplayChatCompletionClient(
+        responses,
+        model_info=ModelInfo(
+            vision=False,
+            function_calling=True,
+            json_output=False,
+            family="unknown",
+        ),
+    )
+    tools = [echo, *(agentflow_tools or [])]
+    return AssistantAgent(
+        name="assistant",
+        model_client=client,
+        tools=tools,
+        reflect_on_tool_use=False,
+    )
+
+
+def bridged_tool_agent(*, agentflow_tools=None) -> AssistantAgent:
+    usage = RequestUsage(prompt_tokens=5, completion_tokens=2)
+    tool_name = "echo"
+    if agentflow_tools:
+        tool_name = getattr(agentflow_tools[0], "name", tool_name)
+    call = FunctionCall(
+        id="bridge-call",
+        name=tool_name,
+        arguments=json.dumps({"text": "ping"}),
+    )
+    responses = [
+        CreateResult(content=[call], finish_reason="function_calls", usage=usage, cached=False),
+        CreateResult(content="bridged", finish_reason="stop", usage=usage, cached=False),
+    ]
+    client = ReplayChatCompletionClient(
+        responses,
+        model_info=ModelInfo(
+            vision=False,
+            function_calling=True,
+            json_output=False,
+            family="unknown",
+        ),
+    )
+    tools = list(agentflow_tools or [])
+    return AssistantAgent(
+        name="assistant",
+        model_client=client,
+        tools=tools,
+        reflect_on_tool_use=False,
+    )
+
+
+def writer_agent() -> AssistantAgent:
+    client = ReplayChatCompletionClient(["Writer says hi"])
+    return AssistantAgent(name="writer", model_client=client)
+
+
+def editor_agent() -> AssistantAgent:
+    client = ReplayChatCompletionClient(["Editor approves"])
+    return AssistantAgent(name="editor", model_client=client)
+
+
+def create_team() -> RoundRobinGroupChat:
+    return RoundRobinGroupChat([writer_agent(), editor_agent()], max_turns=2)
+
+
+def failing_bridged_agent(*, agentflow_tools=None) -> AssistantAgent:
+    usage = RequestUsage(prompt_tokens=5, completion_tokens=2)
+    call = FunctionCall(id="bridge-call", name="bridge_failure", arguments="{}")
+    responses = [
+        CreateResult(content=[call], finish_reason="function_calls", usage=usage, cached=False),
+        CreateResult(content="failed", finish_reason="stop", usage=usage, cached=False),
+    ]
+    client = ReplayChatCompletionClient(
+        responses,
+        model_info=ModelInfo(
+            vision=False,
+            function_calling=True,
+            json_output=False,
+            family="unknown",
+        ),
+    )
+    tools = list(agentflow_tools or [])
+    return AssistantAgent(
+        name="assistant",
+        model_client=client,
+        tools=tools,
+        reflect_on_tool_use=False,
+    )
+
+
+def not_a_runnable() -> TaskResult:
+    return TaskResult(messages=[TextMessage(content="nope", source="assistant")])
+
+
+@pytest.mark.asyncio
+async def test_factory_run_streams_messages_and_usage() -> None:
+    adapter = create_adapter()
+    ctx = RecordingContext({"agent_factory": factory_reference("text_agent")})
+
+    result = await adapter.run(ctx)
+
+    assert isinstance(adapter, AutoGenAdapter)
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output == {"reply": "Hello from AutoGen"}
+    assert ctx.event("step.started") == [{"index": 0, "node": "autogen"}]
+    assert "".join(item["delta"] for item in ctx.event("token.delta")) == "Hello from AutoGen"
+    assert [item["role"] for item in ctx.event("message.created")] == ["user", "assistant"]
+    assert ctx.event("step.completed")[0]["tokens_in"] > 0
+    assert ctx.event("step.completed")[0]["output"] == result.output
+
+
+@pytest.mark.asyncio
+async def test_native_tool_events_use_agentflow_ids() -> None:
+    ctx = RecordingContext({"agent_factory": factory_reference("tool_agent")})
+
+    result = await AutoGenAdapter().run(ctx)
+
+    assert result.status == RunStatus.SUCCEEDED
+    started = ctx.event("tool_call.started")[0]
+    completed = ctx.event("tool_call.completed")[0]
+    assert started["name"] == "echo"
+    assert started["arguments"] == {"text": "ping"}
+    assert len(started["call_id"]) == 26
+    assert started["call_id"] != "provider-call-id"
+    assert completed["call_id"] == started["call_id"]
+    assert completed["result"] == {"result": "echo:ping"}
+    assert completed["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_agentflow_builtin_tool_is_injected_without_duplicate_events() -> None:
+    ctx = RecordingContext(
+        {
+            "agent_factory": factory_reference("bridged_tool_agent"),
+            "tools": ["echo"],
+        }
+    )
+
+    result = await AutoGenAdapter().run(ctx)
+
+    assert result.status == RunStatus.SUCCEEDED
+    started = ctx.event("tool_call.started")
+    completed = ctx.event("tool_call.completed")
+    assert len(started) == len(completed) == 1
+    assert started[0]["name"] == "echo"
+    assert completed[0]["result"] == {"text": "ping"}
+    assert completed[0]["call_id"] == started[0]["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_team_run_emits_one_step_per_turn() -> None:
+    ctx = RecordingContext(
+        {
+            "team_factory": factory_reference("create_team"),
+            "per_turn_steps": True,
+        },
+        prompt="collab",
+    )
+
+    result = await AutoGenAdapter().run(ctx)
+
+    assert result.status == RunStatus.SUCCEEDED
+    assert result.output["reply"] == "Editor approves"
+    assert result.output["replies"] == ["Writer says hi", "Editor approves"]
+    assert [step["node"] for step in ctx.event("step.started")] == ["writer", "editor"]
+    assert len(ctx.event("step.completed")) == 2
+
+
+@pytest.mark.asyncio
+async def test_invalid_factory_becomes_a_failed_step() -> None:
+    ctx = RecordingContext({"agent_factory": factory_reference("not_a_runnable")})
+
+    result = await AutoGenAdapter().run(ctx)
+
+    assert result.status == RunStatus.FAILED
+    assert "run_stream" in (result.error or "")
+    assert ctx.event("step.failed")[0]["error"] == result.error
+
+
+@pytest.mark.asyncio
+async def test_agentflow_tool_failure_is_emitted_once() -> None:
+    async def fail(_arguments: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("bridge exploded")
+
+    register_tool("bridge_failure", fail)
+    ctx = RecordingContext(
+        {
+            "agent_factory": factory_reference("failing_bridged_agent"),
+            "tools": ["bridge_failure"],
+        }
+    )
+
+    result = await AutoGenAdapter().run(ctx)
+
+    assert result.status == RunStatus.FAILED
+    assert result.error == "bridge exploded"
+    assert len(ctx.event("tool_call.started")) == 1
+    assert len(ctx.event("tool_call.completed")) == 1
+    assert ctx.event("tool_call.completed")[0]["error"] == "bridge exploded"


### PR DESCRIPTION
- Introduced the AutoGen adapter plugin, enabling integration of AutoGen AgentChat agents and teams with AgentFlow's runtime.
- Added configuration options for single-agent and team runs, including support for token streaming and tool event translation.
- Created comprehensive documentation for installation and usage in the new `integrations/autogen` directory.
- Implemented unit tests to ensure functionality and reliability of the adapter.

This enhancement expands the capabilities of AgentFlow by allowing seamless interaction with AutoGen agents.
