### PR TITLE
feat: implement tool error handling and recovery policy

### DIFF
--- a/backend/app/adapters/__init__.py
+++ b/backend/app/adapters/__init__.py
@@ -29,6 +29,7 @@ from app.adapters.mcp_client import (
     parse_mcp_servers,
 )
 from app.adapters.mcp_tools import RunToolResolver, resolve_run_tools
+from app.adapters.tool_errors import RecoverableToolError
 from app.adapters.tool_registry import (
     ToolDefinition,
     get_tool,
@@ -51,6 +52,7 @@ __all__ = [
     "McpServerConfig",
     "McpSessionManager",
     "OrchestratorAdapter",
+    "RecoverableToolError",
     "RunToolResolver",
     "ToolDefinition",
     "build_tool_arguments",

--- a/backend/app/adapters/adapter_tools.py
+++ b/backend/app/adapters/adapter_tools.py
@@ -125,16 +125,6 @@ class AdapterToolSurface:
         started = time.monotonic()
         try:
             result = await tool.handler(arguments)
-            if not isinstance(result, dict):
-                result = {"result": result}
-            await ctx.emit_tool_call_completed(
-                step_index=step_index,
-                name=tool.name,
-                call_id=cid,
-                result=result,
-                latency_ms=int((time.monotonic() - started) * 1000),
-            )
-            return result
         except Exception as exc:
             await ctx.emit_tool_call_completed(
                 step_index=step_index,
@@ -144,6 +134,17 @@ class AdapterToolSurface:
                 latency_ms=int((time.monotonic() - started) * 1000),
             )
             raise
+
+        if not isinstance(result, dict):
+            result = {"result": result}
+        await ctx.emit_tool_call_completed(
+            step_index=step_index,
+            name=tool.name,
+            call_id=cid,
+            result=result,
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
+        return result
 
 
 @asynccontextmanager

--- a/backend/app/adapters/langgraph_adapter.py
+++ b/backend/app/adapters/langgraph_adapter.py
@@ -23,6 +23,7 @@ Expected agent.config shape (all optional except when using custom graphs):
   ],
   "mcp_auto_register": false,  // register every tool from mcp_servers
   "max_tool_rounds": 4,        // agent-node ReAct iterations (default 4)
+  "tool_error_policy": "feedback", // fail_fast (default) | feedback
   "graph": {
     "nodes": [
       {"id": "agent", "type": "agent"},
@@ -62,7 +63,7 @@ import json
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from app.adapters.adapter_tools import (
     AdapterToolSurface,
@@ -70,6 +71,10 @@ from app.adapters.adapter_tools import (
     tool_schemas_from_definitions,
 )
 from app.adapters.base import AdapterContext, AdapterResult, OrchestratorAdapter
+from app.adapters.tool_errors import (
+    RecoverableToolError,
+    build_safe_tool_error_observation,
+)
 from app.adapters.tool_registry import ToolDefinition
 from app.core.config import get_settings
 from app.core.logging import get_logger
@@ -82,6 +87,37 @@ logger = get_logger("adapter.langgraph")
 START_NODE = "__start__"
 END_NODE = "__end__"
 DEFAULT_MAX_TOOL_ROUNDS = 4
+DEFAULT_TOOL_ERROR_POLICY = "fail_fast"
+ToolErrorPolicy = Literal["fail_fast", "feedback"]
+
+
+class ToolRecoveryExhaustedError(Exception):
+    """Raised when recoverable tool feedback exhausts ``max_tool_rounds``."""
+
+    def __init__(self, max_tool_rounds: int) -> None:
+        self.max_tool_rounds = max_tool_rounds
+        super().__init__(
+            f"tool_recovery_exhausted: reached max_tool_rounds={max_tool_rounds}"
+        )
+
+
+def parse_tool_error_policy(config: dict[str, Any]) -> ToolErrorPolicy:
+    """Parse and validate agent-level ``tool_error_policy``."""
+    raw = config.get("tool_error_policy", DEFAULT_TOOL_ERROR_POLICY)
+    if raw not in ("fail_fast", "feedback"):
+        raise ValueError(
+            f"invalid tool_error_policy={raw!r}; expected fail_fast|feedback"
+        )
+    return raw  # type: ignore[return-value]
+
+
+@dataclass
+class ToolOutcome:
+    """Result of one agent-node tool invocation."""
+
+    call: dict[str, Any]
+    result: dict[str, Any] | None = None
+    error_observation: dict[str, Any] | None = None
 
 
 class WaitingHumanInterrupt(Exception):
@@ -234,6 +270,7 @@ class _RunState:
     default_model: str
     default_system_prompt: str
     max_tool_rounds: int = DEFAULT_MAX_TOOL_ROUNDS
+    tool_error_policy: ToolErrorPolicy = DEFAULT_TOOL_ERROR_POLICY
     step_index: int = 0
     node_indices: dict[str, int] = field(default_factory=dict)
 
@@ -270,6 +307,12 @@ class LangGraphAdapter(OrchestratorAdapter):
             await tool_surface.close()
             return AdapterResult(status=RunStatus.FAILED, error=str(exc))
 
+        try:
+            tool_error_policy = parse_tool_error_policy(config)
+        except ValueError as exc:
+            await tool_surface.close()
+            return AdapterResult(status=RunStatus.FAILED, error=str(exc))
+
         max_rounds = int(config.get("max_tool_rounds", DEFAULT_MAX_TOOL_ROUNDS))
         run_state = _RunState(
             ctx=ctx,
@@ -281,6 +324,7 @@ class LangGraphAdapter(OrchestratorAdapter):
                 config.get("system_prompt", "You are a helpful agent.")
             ),
             max_tool_rounds=max(1, max_rounds),
+            tool_error_policy=tool_error_policy,
         )
 
         graph = StateGraph(dict)
@@ -517,6 +561,8 @@ class LangGraphAdapter(OrchestratorAdapter):
             total_in = 0
             total_out = 0
             final_reply = ""
+            had_recoverable_feedback = False
+            policy = run_state.tool_error_policy
 
             await ctx.emit_step_started(index=step_idx, node=spec.id)
             await ctx.emit_message(role="system", content=system_prompt)
@@ -550,30 +596,50 @@ class LangGraphAdapter(OrchestratorAdapter):
                             }
                         )
 
-                        async def _run_tool(tc: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+                        async def _run_one_tool(tc: dict[str, Any]) -> ToolOutcome:
                             name = str(tc.get("name") or "")
                             arguments = dict(tc.get("arguments") or {})
-                            result = await run_state.tool_surface.execute(
-                                ctx,
-                                step_index=step_idx,
-                                name=name,
-                                arguments=arguments,
-                            )
-                            return tc, result
+                            try:
+                                result = await run_state.tool_surface.execute(
+                                    ctx,
+                                    step_index=step_idx,
+                                    name=name,
+                                    arguments=arguments,
+                                )
+                                return ToolOutcome(call=tc, result=result)
+                            except RecoverableToolError as exc:
+                                if policy == "fail_fast":
+                                    raise
+                                return ToolOutcome(
+                                    call=tc,
+                                    error_observation=build_safe_tool_error_observation(
+                                        tool_name=name,
+                                        exc=exc,
+                                    ),
+                                )
 
                         # Parallel tool calls share one step; call_id keeps
                         # started/completed pairs associated correctly.
-                        pairs = await asyncio.gather(
-                            *[_run_tool(tc) for tc in response.tool_calls]
+                        outcomes = await asyncio.gather(
+                            *[_run_one_tool(tc) for tc in response.tool_calls]
                         )
-                        for tc, result in pairs:
+                        for outcome in outcomes:
+                            tc = outcome.call
                             name = str(tc.get("name") or "")
-                            tool_results[name] = result
+                            if outcome.result is not None:
+                                tool_results[name] = outcome.result
+                                content = json.dumps(outcome.result, default=str)
+                            else:
+                                assert outcome.error_observation is not None
+                                had_recoverable_feedback = True
+                                content = json.dumps(
+                                    outcome.error_observation, default=str
+                                )
                             messages.append(
                                 {
                                     "role": "tool",
                                     "tool_call_id": str(tc.get("id") or name),
-                                    "content": json.dumps(result, default=str),
+                                    "content": content,
                                 }
                             )
                         continue
@@ -582,6 +648,8 @@ class LangGraphAdapter(OrchestratorAdapter):
                     messages.append({"role": "assistant", "content": final_reply})
                     break
                 else:
+                    if policy == "feedback" and had_recoverable_feedback:
+                        raise ToolRecoveryExhaustedError(max_rounds)
                     final_reply = (
                         final_reply
                         or f"[agent:{spec.id}] reached max_tool_rounds={max_rounds}"

--- a/backend/app/adapters/mcp_client.py
+++ b/backend/app/adapters/mcp_client.py
@@ -10,6 +10,10 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from app.adapters.tool_errors import (
+    MCP_TOOL_ERROR_PUBLIC_MESSAGE,
+    RecoverableToolError,
+)
 from app.core.logging import get_logger
 
 logger = get_logger("adapter.mcp")
@@ -211,7 +215,11 @@ class McpSessionManager:
         payload = serialize_call_tool_result(result)
         if payload.get("is_error"):
             message = payload.get("text") or f"MCP tool {tool_name!r} returned an error"
-            raise RuntimeError(message)
+            raise RecoverableToolError(
+                code="mcp_tool_error",
+                public_message=MCP_TOOL_ERROR_PUBLIC_MESSAGE,
+                internal_message=message,
+            )
         return payload
 
     async def _require_session(self, server_name: str) -> Any:

--- a/backend/app/adapters/tool_errors.py
+++ b/backend/app/adapters/tool_errors.py
@@ -1,0 +1,50 @@
+"""Explicit recoverable tool failure contract for agent feedback."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_CODE_PATTERN = re.compile(r"^[a-z0-9_]{1,64}$")
+_MAX_PUBLIC_MESSAGE_LEN = 512
+
+MCP_TOOL_ERROR_PUBLIC_MESSAGE = (
+    "The MCP tool returned an error. "
+    "Revise the request or choose another tool."
+)
+
+
+class RecoverableToolError(Exception):
+    """Tool failure that may be safely surfaced to the agent as an observation."""
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        public_message: str,
+        internal_message: str | None = None,
+    ) -> None:
+        if not _CODE_PATTERN.match(code):
+            raise ValueError(f"invalid recoverable tool error code: {code!r}")
+        if len(public_message) > _MAX_PUBLIC_MESSAGE_LEN:
+            public_message = public_message[:_MAX_PUBLIC_MESSAGE_LEN]
+        super().__init__(internal_message or public_message)
+        self.code = code
+        self.public_message = public_message
+
+
+def build_safe_tool_error_observation(
+    *,
+    tool_name: str,
+    exc: RecoverableToolError,
+) -> dict[str, Any]:
+    """Build a structured, safe tool error observation for the agent loop."""
+    return {
+        "ok": False,
+        "error": {
+            "type": "recoverable_tool_error",
+            "code": exc.code,
+            "tool": tool_name,
+            "message": exc.public_message,
+        },
+    }

--- a/backend/tests/test_adapter_tools.py
+++ b/backend/tests/test_adapter_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,7 @@ from app.adapters.adapter_tools import (
     open_tool_surface,
 )
 from app.adapters.base import AdapterContext
+from app.adapters.tool_errors import RecoverableToolError
 from app.adapters.tool_registry import ToolDefinition, get_tool
 
 _FIXTURE_SERVER = Path(__file__).resolve().parent / "fixtures" / "mcp_echo_server.py"
@@ -99,3 +101,55 @@ async def test_open_tool_surface_context_manager():
         tool = surface.lookup("echo")
         assert isinstance(tool, ToolDefinition)
         assert tool.name == "echo"
+
+
+async def _raise_recoverable(_args: dict[str, Any]) -> dict[str, Any]:
+    raise RecoverableToolError(
+        code="recoverable",
+        public_message="safe message",
+        internal_message="raw internal detail",
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_tool_surface_preserves_recoverable_error_type():
+    from app.adapters.tool_registry import register_tool
+
+    register_tool("recoverable_probe", _raise_recoverable, overwrite=True)
+    ctx = _RecordingContext()
+    surface = await AdapterToolSurface.open({"tools": ["recoverable_probe"]}, ["recoverable_probe"])
+    try:
+        with pytest.raises(RecoverableToolError) as exc_info:
+            await surface.execute(
+                ctx,
+                step_index=0,
+                name="recoverable_probe",
+                arguments={},
+            )
+        assert exc_info.value.code == "recoverable"
+        completed = [d for e, d in ctx.events if e == "tool_call.completed"]
+        assert completed[0]["error"] == "raw internal detail"
+    finally:
+        await surface.close()
+
+
+@pytest.mark.asyncio
+async def test_adapter_tool_surface_cancellation_propagates():
+    async def _cancelled(_args: dict[str, Any]) -> dict[str, Any]:
+        raise asyncio.CancelledError()
+
+    from app.adapters.tool_registry import register_tool
+
+    register_tool("cancel_probe", _cancelled, overwrite=True)
+    ctx = _RecordingContext()
+    surface = await AdapterToolSurface.open({"tools": ["cancel_probe"]}, ["cancel_probe"])
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await surface.execute(
+                ctx,
+                step_index=0,
+                name="cancel_probe",
+                arguments={},
+            )
+    finally:
+        await surface.close()

--- a/backend/tests/test_mcp_adapter.py
+++ b/backend/tests/test_mcp_adapter.py
@@ -136,3 +136,40 @@ async def test_mcp_adapter_config_steps():
     result = await adapter.run(ctx)
     assert result.status == RunStatus.SUCCEEDED
     assert result.output["result"]["text"] == "from-config"
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_recoverable_error_still_fails_fast(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.adapters.mcp_client import McpSessionManager
+    from app.adapters.tool_errors import RecoverableToolError
+
+    async def _fake_call_tool(
+        self: McpSessionManager,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise RecoverableToolError(
+            code="mcp_tool_error",
+            public_message=(
+                "The MCP tool returned an error. "
+                "Revise the request or choose another tool."
+            ),
+            internal_message="raw mcp failure",
+        )
+
+    monkeypatch.setattr(McpSessionManager, "call_tool", _fake_call_tool)
+
+    adapter = McpAdapter()
+    ctx = _RecordingContext(
+        agent_config={"mcp_servers": [_mcp_server_config()]},
+        input={"tool": "mcp/echo/ping", "arguments": {"message": "x"}},
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.FAILED
+    assert "raw mcp failure" in (result.error or "")
+    completed = [d for e, d in ctx.events if e == "tool_call.completed"]
+    assert len(completed) == 1
+    assert completed[0]["error"] == "raw mcp failure"

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -134,8 +134,10 @@ async def test_langgraph_mcp_tool_writes_tool_call_events():
 async def test_mcp_call_tool_raises_on_error():
     from unittest.mock import AsyncMock, MagicMock
 
-    from app.adapters.mcp_client import McpSessionManager, McpServerConfig
     from mcp.types import CallToolResult, TextContent
+
+    from app.adapters.mcp_client import McpServerConfig, McpSessionManager
+    from app.adapters.tool_errors import RecoverableToolError
 
     manager = McpSessionManager(
         [McpServerConfig(name="echo", transport="stdio", command="true")]
@@ -149,8 +151,12 @@ async def test_mcp_call_tool_raises_on_error():
     )
     manager._sessions["echo"] = session
 
-    with pytest.raises(RuntimeError, match="bad input"):
+    with pytest.raises(RecoverableToolError) as exc_info:
         await manager.call_tool("echo", "ping", {"message": "x"})
+    assert exc_info.value.code == "mcp_tool_error"
+    assert "bad input" in str(exc_info.value)
+    assert "bad input" not in exc_info.value.public_message
+    assert "Revise the request" in exc_info.value.public_message
 
 
 def test_serialize_call_tool_result_text():

--- a/backend/tests/test_tool_failure_recovery.py
+++ b/backend/tests/test_tool_failure_recovery.py
@@ -1,0 +1,517 @@
+"""ReAct tool failure recovery — policy, observations, parallel, and exhaustion."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from app.adapters.base import AdapterContext
+from app.adapters.langgraph_adapter import (
+    LangGraphAdapter,
+    ModelResponse,
+    ToolRecoveryExhaustedError,
+    parse_tool_error_policy,
+)
+from app.adapters.tool_errors import RecoverableToolError, build_safe_tool_error_observation
+from app.adapters.tool_registry import register_tool
+from app.db.base import Base
+from app.db.session import SessionLocal, engine
+from app.events import get_event_bus
+from app.models import Agent, Step, ToolCall
+from app.models.run import RunStatus as RunStatusEnum
+from app.schemas.run import RunCreate
+from app.services.run_service import RunService
+from app.worker.cancel import InMemoryCancelRegistry
+from app.worker.executor import RunExecutor
+
+
+class _RecordingContext(AdapterContext):
+    def __init__(self, **kwargs: Any) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+        super().__init__(
+            run_id="01TEST",
+            agent_id="01AGENT",
+            agent_config={},
+            input={"prompt": "hello"},
+            emit=self._emit,
+            **kwargs,
+        )
+
+    async def _emit(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+
+
+def _agent_graph_config(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "model": "openai/gpt-4o-mini",
+        "graph": {
+            "nodes": [{"id": "worker", "type": "agent"}],
+            "edges": [
+                ["__start__", "worker"],
+                ["worker", "__end__"],
+            ],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+async def _recoverable_fail(_args: dict[str, Any]) -> dict[str, Any]:
+    raise RecoverableToolError(
+        code="bad_args",
+        public_message="Fix your parameters and try again.",
+        internal_message="secret raw validation error",
+    )
+
+
+async def _fatal_fail(_args: dict[str, Any]) -> dict[str, Any]:
+    raise RuntimeError("programming bug")
+
+
+async def _slow_success(args: dict[str, Any]) -> dict[str, Any]:
+    await asyncio.sleep(0.05)
+    return {"text": str(args.get("text", "ok"))}
+
+
+@pytest.fixture(autouse=True)
+def _register_recovery_tools():
+    register_tool("recovery_fail", _recoverable_fail, overwrite=True)
+    register_tool("recovery_fatal", _fatal_fail, overwrite=True)
+    register_tool("recovery_slow", _slow_success, overwrite=True)
+    yield
+
+
+def test_parse_tool_error_policy_defaults_to_fail_fast():
+    assert parse_tool_error_policy({}) == "fail_fast"
+
+
+def test_parse_tool_error_policy_rejects_invalid():
+    with pytest.raises(ValueError, match="invalid tool_error_policy"):
+        parse_tool_error_policy({"tool_error_policy": "retry"})
+
+
+def test_build_safe_observation_excludes_internal_message():
+    exc = RecoverableToolError(
+        code="bad_args",
+        public_message="safe text",
+        internal_message="secret raw error",
+    )
+    obs = build_safe_tool_error_observation(tool_name="recovery_fail", exc=exc)
+    serialized = json.dumps(obs)
+    assert obs["ok"] is False
+    assert obs["error"]["type"] == "recoverable_tool_error"
+    assert obs["error"]["code"] == "bad_args"
+    assert obs["error"]["message"] == "safe text"
+    assert "secret" not in serialized
+    assert "traceback" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_fail_fast_on_recoverable_error():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(tools=["recovery_fail"])
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.FAILED
+    assert "secret raw validation error" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_explicit_fail_fast_on_recoverable_error():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["recovery_fail"],
+        tool_error_policy="fail_fast",
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.FAILED
+
+
+@pytest.mark.asyncio
+async def test_feedback_converts_recoverable_to_observation_and_recovers():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["recovery_fail"],
+        tool_error_policy="feedback",
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.SUCCEEDED
+    reply = (result.output or {}).get("reply", "")
+    assert "recoverable_tool_error" in reply or "Fix your parameters" in reply
+
+    completed = [
+        data for event, data in ctx.events if event == "tool_call.completed"
+    ]
+    assert completed[0]["error"] == "secret raw validation error"
+    assert "secret" not in reply
+
+
+@pytest.mark.asyncio
+async def test_feedback_fatal_runtime_error_still_fails():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["recovery_fatal"],
+        tool_error_policy="feedback",
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.FAILED
+    assert "programming bug" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_invalid_policy_fails_before_tool_execution():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["echo"],
+        tool_error_policy="retry",
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.FAILED
+    assert "invalid tool_error_policy" in (result.error or "")
+    assert not any(e.startswith("tool_call.") for e, _ in ctx.events)
+
+
+@pytest.mark.asyncio
+async def test_feedback_fallback_tool_success(monkeypatch: pytest.MonkeyPatch):
+    scripted: list[ModelResponse] = [
+        ModelResponse(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_fail",
+                    "name": "recovery_fail",
+                    "arguments": {},
+                }
+            ],
+            tokens_in=1,
+            tokens_out=1,
+        ),
+        ModelResponse(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_echo",
+                    "name": "echo",
+                    "arguments": {"text": "hi"},
+                }
+            ],
+            tokens_in=1,
+            tokens_out=1,
+        ),
+        ModelResponse(content="fallback succeeded", tokens_in=1, tokens_out=1),
+    ]
+    call_idx = {"n": 0}
+
+    async def _scripted_invoke(
+        self: LangGraphAdapter,
+        ctx: AdapterContext,
+        step_index: int,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> ModelResponse:
+        idx = min(call_idx["n"], len(scripted) - 1)
+        call_idx["n"] += 1
+        return scripted[idx]
+
+    monkeypatch.setattr(LangGraphAdapter, "_invoke_model", _scripted_invoke)
+
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["recovery_fail", "echo"],
+        tool_error_policy="feedback",
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.SUCCEEDED
+    assert result.output == {"reply": "fallback succeeded"}
+    assert call_idx["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_feedback_parallel_success_and_recoverable(monkeypatch: pytest.MonkeyPatch):
+    async def _scripted_invoke(
+        self: LangGraphAdapter,
+        ctx: AdapterContext,
+        step_index: int,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> ModelResponse:
+        if not any(m.get("role") == "tool" for m in messages):
+            return ModelResponse(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_ok",
+                        "name": "echo",
+                        "arguments": {"text": "a"},
+                    },
+                    {
+                        "id": "call_bad",
+                        "name": "recovery_fail",
+                        "arguments": {},
+                    },
+                ],
+                tokens_in=1,
+                tokens_out=1,
+            )
+        return ModelResponse(content="used partial results", tokens_in=1, tokens_out=1)
+
+    monkeypatch.setattr(LangGraphAdapter, "_invoke_model", _scripted_invoke)
+
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["echo", "recovery_fail"],
+        tool_error_policy="feedback",
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.SUCCEEDED
+
+    checkpoints = [
+        data for event, data in ctx.events if event == "checkpoint.created"
+    ]
+    messages = checkpoints[-1]["state"]["graph_state"]["messages"]
+    tool_msgs = [
+        (m["tool_call_id"], json.loads(m["content"]))
+        for m in messages
+        if m.get("role") == "tool"
+    ]
+    assert len(tool_msgs) == 2
+    assert tool_msgs[0][0] == "call_ok"
+    assert tool_msgs[1][0] == "call_bad"
+    assert tool_msgs[0][1] == {"text": "a"}
+    assert tool_msgs[1][1]["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_feedback_parallel_fatal_fails_step(monkeypatch: pytest.MonkeyPatch):
+    async def _scripted_invoke(
+        self: LangGraphAdapter,
+        ctx: AdapterContext,
+        step_index: int,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> ModelResponse:
+        return ModelResponse(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_ok",
+                    "name": "echo",
+                    "arguments": {"text": "a"},
+                },
+                {
+                    "id": "call_fatal",
+                    "name": "recovery_fatal",
+                    "arguments": {},
+                },
+            ],
+            tokens_in=1,
+            tokens_out=1,
+        )
+
+    monkeypatch.setattr(LangGraphAdapter, "_invoke_model", _scripted_invoke)
+
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["echo", "recovery_fatal"],
+        tool_error_policy="feedback",
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.FAILED
+    assert "programming bug" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_feedback_recovery_exhausted(monkeypatch: pytest.MonkeyPatch):
+    async def _always_tool_call(
+        self: LangGraphAdapter,
+        ctx: AdapterContext,
+        step_index: int,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> ModelResponse:
+        return ModelResponse(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_fail",
+                    "name": "recovery_fail",
+                    "arguments": {},
+                }
+            ],
+            tokens_in=1,
+            tokens_out=1,
+        )
+
+    monkeypatch.setattr(LangGraphAdapter, "_invoke_model", _always_tool_call)
+
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["recovery_fail"],
+        tool_error_policy="feedback",
+        max_tool_rounds=2,
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.FAILED
+    assert "tool_recovery_exhausted" in (result.error or "")
+    assert "max_tool_rounds=2" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_max_rounds_without_recoverable_feedback_keeps_legacy_success(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def _always_tool_call(
+        self: LangGraphAdapter,
+        ctx: AdapterContext,
+        step_index: int,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> ModelResponse:
+        return ModelResponse(
+            content="",
+            tool_calls=[
+                {"id": "call_echo", "name": "echo", "arguments": {"text": "x"}}
+            ],
+            tokens_in=1,
+            tokens_out=1,
+        )
+
+    monkeypatch.setattr(LangGraphAdapter, "_invoke_model", _always_tool_call)
+
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["echo"],
+        tool_error_policy="feedback",
+        max_tool_rounds=1,
+    )
+    result = await adapter.run(ctx)
+    assert result.status == RunStatusEnum.SUCCEEDED
+    assert "reached max_tool_rounds=1" in (result.output or {}).get("reply", "")
+
+
+@pytest.mark.asyncio
+async def test_provider_tool_call_id_paired_with_lifecycle_call_id():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = _agent_graph_config(
+        tools=["recovery_fail"],
+        tool_error_policy="feedback",
+    )
+    await adapter.run(ctx)
+
+    started = [d for e, d in ctx.events if e == "tool_call.started"]
+    completed = [d for e, d in ctx.events if e == "tool_call.completed"]
+    checkpoints = [
+        data for event, data in ctx.events if event == "checkpoint.created"
+    ]
+    tool_msgs = [
+        m for m in checkpoints[-1]["state"]["graph_state"]["messages"]
+        if m.get("role") == "tool"
+    ]
+    assert started[0]["call_id"] == completed[0]["call_id"]
+    assert len(started[0]["call_id"]) == 26
+    assert tool_msgs[0]["tool_call_id"] == "call_recovery_fail"
+    assert tool_msgs[0]["tool_call_id"] != started[0]["call_id"]
+
+
+def test_tool_recovery_exhausted_error_message():
+    err = ToolRecoveryExhaustedError(4)
+    assert "tool_recovery_exhausted" in str(err)
+    assert "max_tool_rounds=4" in str(err)
+
+
+@pytest.mark.asyncio
+async def test_executor_persists_raw_error_but_not_in_model_observation(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    async def _scripted_invoke(
+        self: LangGraphAdapter,
+        ctx: AdapterContext,
+        step_index: int,
+        model: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> ModelResponse:
+        if not any(m.get("role") == "tool" for m in messages):
+            return ModelResponse(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_fail",
+                        "name": "recovery_fail",
+                        "arguments": {},
+                    }
+                ],
+                tokens_in=1,
+                tokens_out=1,
+            )
+        return ModelResponse(content="recovered", tokens_in=1, tokens_out=1)
+
+    monkeypatch.setattr(LangGraphAdapter, "_invoke_model", _scripted_invoke)
+
+    bus = get_event_bus()
+    async with SessionLocal() as session:
+        agent = Agent(
+            name="recovery-agent",
+            adapter="langgraph",
+            config=_agent_graph_config(
+                tools=["recovery_fail"],
+                tool_error_policy="feedback",
+            ),
+        )
+        session.add(agent)
+        await session.commit()
+        await session.refresh(agent)
+
+        service = RunService(session=session, bus=bus)
+        run = await service.create_run(
+            RunCreate(agent_id=agent.id, input={"prompt": "hello"})
+        )
+        run_id = run.id
+
+    executor = RunExecutor(bus=bus, cancel_registry=InMemoryCancelRegistry())
+    await executor.execute(run_id, "langgraph")
+
+    async with SessionLocal() as session:
+        from app.models.run import Run
+
+        finished = (
+            await session.execute(select(Run).where(Run.id == run_id))
+        ).scalar_one()
+        assert finished.status == RunStatusEnum.SUCCEEDED
+
+        step = (
+            await session.execute(
+                select(Step).where(Step.run_id == run_id, Step.index == 0)
+            )
+        ).scalar_one()
+        calls = (
+            await session.execute(
+                select(ToolCall).where(ToolCall.step_id == step.id)
+            )
+        ).scalars().all()
+        assert len(calls) == 1
+        assert calls[0].error == "secret raw validation error"
+        assert calls[0].result is None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,37 @@ Alternatively pass a single call or batch in run `input`:
 LangGraph graphs can invoke the same MCP tools via `type: "tool"` or
 `type: "agent"` nodes without a separate adapter.
 
+### ReAct tool failure recovery
+
+LangGraph `agent` nodes support an optional `tool_error_policy` in agent
+config:
+
+| Policy | Behavior |
+| --- | --- |
+| `fail_fast` (default) | Any tool exception fails the step/run (unchanged) |
+| `feedback` | Only explicit `RecoverableToolError` becomes a safe tool observation; fatal errors still fail-fast |
+
+Recoverable failures include MCP `CallToolResult.is_error=true` (mapped to a
+fixed public message) and custom tools that raise `RecoverableToolError`.
+Programming errors, transport/session failures, and cancellation continue to
+propagate. Raw errors are persisted on `ToolCall.error`; the model only sees
+a structured observation without traceback, arguments, or raw MCP text.
+
+Provider `tool_call_id` values pair assistant tool calls with `role=tool`
+messages. AgentFlow lifecycle ULIDs pair `tool_call.started` /
+`tool_call.completed` events with `ToolCall.id` rows — these identifiers are
+not unified in v1.
+
+Parallel tool calls use standard `asyncio.gather` semantics: recoverable
+failures can coexist with successes in one round, but a fatal error in any
+parallel call fails the step without cancelling siblings or rolling back side
+effects. `tool_error_policy` is interpreted only by LangGraph `agent` nodes;
+the direct `mcp` adapter and PydanticAI bridge remain fail-fast.
+
+When `feedback` is enabled and recoverable observations exhaust
+`max_tool_rounds` without a final model reply, the run fails with
+`tool_recovery_exhausted: reached max_tool_rounds=N`.
+
 ## Unit tests
 
 The Python test suite in `backend/tests/` exercises adapter and queue logic

--- a/integrations/pydantic-ai/tests/test_adapter.py
+++ b/integrations/pydantic-ai/tests/test_adapter.py
@@ -181,6 +181,34 @@ async def test_agentflow_tool_failure_is_emitted_once() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agentflow_recoverable_tool_failure_stays_fail_fast() -> None:
+    from app.adapters.tool_errors import RecoverableToolError
+
+    async def fail(_arguments: dict[str, Any]) -> dict[str, Any]:
+        raise RecoverableToolError(
+            code="bridge_recoverable",
+            public_message="safe bridge message",
+            internal_message="raw bridge failure",
+        )
+
+    register_tool("bridge_recoverable", fail, overwrite=True)
+
+    def recoverable_tool_agent() -> Agent[None, str]:
+        return Agent(TestModel(call_tools=["bridge_recoverable"]))
+
+    ctx = RecordingContext(factory_reference("recoverable_tool_agent"))
+    ctx.agent_config["tools"] = ["bridge_recoverable"]
+
+    result = await PydanticAIAdapter().run(ctx)
+
+    assert result.status == RunStatus.FAILED
+    assert "raw bridge failure" in (result.error or "")
+    assert len(ctx.event("tool_call.started")) == 1
+    assert len(ctx.event("tool_call.completed")) == 1
+    assert ctx.event("tool_call.completed")[0]["error"] == "raw bridge failure"
+
+
+@pytest.mark.asyncio
 async def test_invalid_factory_becomes_a_failed_step() -> None:
     ctx = RecordingContext(factory_reference("not_an_agent"))
 


### PR DESCRIPTION
- Introduced `tool_error_policy` in agent configuration to manage tool failure behavior, allowing for `fail_fast` and `feedback` options.
- Enhanced `LangGraphAdapter` to handle `RecoverableToolError` and provide structured feedback without exposing raw errors.
- Updated `McpSessionManager` to raise `RecoverableToolError` for MCP tool errors, improving error handling consistency.
- Added tests to verify the behavior of recoverable errors and the new error policy in various scenarios.
- Updated documentation to reflect changes in tool error handling and recovery mechanisms.

This change improves the robustness of tool interactions and enhances user experience by providing clearer error feedback.
