### PR TITLE
feat: enhance message handling and checkpoint management in LangGraphAdapter

### DIFF
--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -43,6 +43,8 @@ class AdapterContext:
     input: dict[str, Any]
     metadata: dict[str, Any] = field(default_factory=dict)
     resume: RunResumeContext | None = None
+    # Ordered chat history loaded from the messages table on retry / resume.
+    run_messages: list[dict[str, Any]] | None = None
     step_index_base: int = 0
     emit: EmitCallback = field(
         default=None  # type: ignore[assignment]
@@ -103,12 +105,23 @@ class AdapterContext:
         )
 
     async def emit_message(
-        self, *, role: str, content: str, name: str | None = None, **extra: Any
+        self,
+        *,
+        role: str,
+        content: str,
+        name: str | None = None,
+        tool_call_id: str | None = None,
+        **extra: Any,
     ) -> None:
-        await self.emit(
-            "message.created",
-            {"role": role, "content": content, "name": name, "extra": extra},
-        )
+        payload: dict[str, Any] = {
+            "role": role,
+            "content": content,
+            "name": name,
+            "extra": extra,
+        }
+        if tool_call_id is not None:
+            payload["tool_call_id"] = tool_call_id
+        await self.emit("message.created", payload)
 
     async def emit_tool_call_started(
         self,

--- a/backend/app/adapters/langgraph_adapter.py
+++ b/backend/app/adapters/langgraph_adapter.py
@@ -471,7 +471,7 @@ class LangGraphAdapter(OrchestratorAdapter):
                 }
                 await ctx.emit_checkpoint(
                     label=spec.id,
-                    state={"graph_state": {**state, **next_state}},
+                    state=_checkpoint_payload({**state, **next_state}),
                 )
                 return next_state
             except Exception as exc:
@@ -516,7 +516,7 @@ class LangGraphAdapter(OrchestratorAdapter):
                 )
                 await ctx.emit_checkpoint(
                     label=spec.id,
-                    state={"graph_state": {**state, **next_state}},
+                    state=_checkpoint_payload({**state, **next_state}),
                 )
                 return next_state
 
@@ -528,7 +528,7 @@ class LangGraphAdapter(OrchestratorAdapter):
             }
             await ctx.emit_checkpoint(
                 label=spec.id,
-                state={"graph_state": pause_state},
+                state=_checkpoint_payload(pause_state),
             )
             raise WaitingHumanInterrupt(
                 output={
@@ -585,15 +585,21 @@ class LangGraphAdapter(OrchestratorAdapter):
                     total_out += response.tokens_out
 
                     if response.tool_calls:
+                        tool_call_payload = [
+                            _openai_tool_call_payload(tc)
+                            for tc in response.tool_calls
+                        ]
                         messages.append(
                             {
                                 "role": "assistant",
                                 "content": response.content or None,
-                                "tool_calls": [
-                                    _openai_tool_call_payload(tc)
-                                    for tc in response.tool_calls
-                                ],
+                                "tool_calls": tool_call_payload,
                             }
+                        )
+                        await ctx.emit_message(
+                            role="assistant",
+                            content=response.content or "",
+                            tool_calls=tool_call_payload,
                         )
 
                         async def _run_one_tool(tc: dict[str, Any]) -> ToolOutcome:
@@ -642,6 +648,11 @@ class LangGraphAdapter(OrchestratorAdapter):
                                     "content": content,
                                 }
                             )
+                            await ctx.emit_message(
+                                role="tool",
+                                content=content,
+                                tool_call_id=str(tc.get("id") or name),
+                            )
                         continue
 
                     final_reply = response.content or ""
@@ -683,7 +694,7 @@ class LangGraphAdapter(OrchestratorAdapter):
                 }
                 await ctx.emit_checkpoint(
                     label=spec.id,
-                    state={"graph_state": {**state, **next_state}},
+                    state=_checkpoint_payload({**state, **next_state}),
                 )
                 return next_state
             except WaitingHumanInterrupt:
@@ -780,7 +791,7 @@ class LangGraphAdapter(OrchestratorAdapter):
             }
             await ctx.emit_checkpoint(
                 label=spec.id,
-                state={"graph_state": {**state, **next_state}},
+                state=_checkpoint_payload({**state, **next_state}),
             )
             return next_state
 
@@ -1034,6 +1045,26 @@ def _openai_tool_call_payload(tc: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_GRAPH_CONTROL_KEYS = (
+    "input",
+    "reply",
+    "tool_results",
+    "completed_nodes",
+    "pending_human",
+    "human_input",
+    "route",
+)
+
+
+def _graph_control_state(state: dict[str, Any]) -> dict[str, Any]:
+    """Graph control fields only — messages are rebuilt from the messages table."""
+    return {key: state[key] for key in _GRAPH_CONTROL_KEYS if key in state}
+
+
+def _checkpoint_payload(state: dict[str, Any]) -> dict[str, Any]:
+    return {"graph_state": _graph_control_state(state)}
+
+
 def _initial_graph_state(ctx: AdapterContext) -> dict[str, Any]:
     default: dict[str, Any] = {
         "input": ctx.input.get("prompt", ""),
@@ -1048,7 +1079,13 @@ def _initial_graph_state(ctx: AdapterContext) -> dict[str, Any]:
     if ctx.resume and ctx.resume.checkpoint_state:
         saved = ctx.resume.checkpoint_state.get("graph_state")
         if isinstance(saved, dict):
-            return {**default, **saved}
+            merged = {**default, **saved}
+            if ctx.run_messages is not None:
+                merged["messages"] = list(ctx.run_messages)
+            elif isinstance(saved.get("messages"), list):
+                # Legacy checkpoints that still inlined messages.
+                merged["messages"] = list(saved["messages"])
+            return merged
     return default
 
 

--- a/backend/app/runtime/messages.py
+++ b/backend/app/runtime/messages.py
@@ -1,0 +1,25 @@
+"""Helpers for rebuilding LangGraph message windows from persisted rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.run import Message
+
+
+def message_row_to_dict(msg: Message) -> dict[str, Any]:
+    """Convert a persisted ``Message`` row to an OpenAI-style chat dict."""
+    payload: dict[str, Any] = {"role": msg.role, "content": msg.content}
+    if msg.name:
+        payload["name"] = msg.name
+    if msg.tool_call_id:
+        payload["tool_call_id"] = msg.tool_call_id
+    extra = msg.extra or {}
+    tool_calls = extra.get("tool_calls")
+    if tool_calls:
+        payload["tool_calls"] = tool_calls
+    return payload
+
+
+def messages_from_rows(rows: list[Message]) -> list[dict[str, Any]]:
+    return [message_row_to_dict(row) for row in rows]

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -36,6 +36,7 @@ from app.core.telemetry import (
     record_step_outcome,
     record_tool_call,
 )
+from app.runtime.messages import messages_from_rows
 from app.runtime.usage import aggregate_run_usage
 from app.schemas.run import EventType, RunCreate, RunEvent, RunResume, RunRetry
 from app.runtime.resume_context import (
@@ -512,6 +513,7 @@ class RunService:
                 step.status = RunStatus.FAILED
                 step.error = data.get("error")
                 await self.session.commit()
+                await self._retain_latest_checkpoint(run_id, reason="pre_failure")
                 run = await self._get_run(run_id)
                 record_step_outcome(
                     adapter=run.adapter,
@@ -578,6 +580,7 @@ class RunService:
             )
             self.session.add(cp)
             await self.session.commit()
+            await self._prune_checkpoints(run_id, keep_index=cp_index)
 
         await self._broadcast(event_type, run_id, data)
 
@@ -633,6 +636,52 @@ class RunService:
         )
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def load_run_messages(self, run_id: str) -> list[dict[str, Any]]:
+        stmt = (
+            select(Message)
+            .where(Message.run_id == run_id)
+            .order_by(Message.index)
+        )
+        result = await self.session.execute(stmt)
+        return messages_from_rows(list(result.scalars().all()))
+
+    async def _retain_latest_checkpoint(
+        self, run_id: str, *, reason: str
+    ) -> None:
+        cp = await self._latest_checkpoint(run_id)
+        if cp is None:
+            return
+        state = dict(cp.state or {})
+        if state.get("retain"):
+            return
+        state["retain"] = True
+        state["retain_reason"] = reason
+        cp.state = state
+        await self.session.commit()
+
+    async def _prune_checkpoints(self, run_id: str, *, keep_index: int) -> None:
+        stmt = (
+            select(Checkpoint)
+            .where(Checkpoint.run_id == run_id)
+            .order_by(Checkpoint.index)
+        )
+        result = await self.session.execute(stmt)
+        checkpoints = list(result.scalars().all())
+        keep_ids: set[str] = set()
+        for cp in checkpoints:
+            state = cp.state or {}
+            graph = state.get("graph_state") or {}
+            if cp.index == keep_index:
+                keep_ids.add(cp.id)
+            elif graph.get("pending_human"):
+                keep_ids.add(cp.id)
+            elif state.get("retain"):
+                keep_ids.add(cp.id)
+        for cp in checkpoints:
+            if cp.id not in keep_ids:
+                await self.session.delete(cp)
+        await self.session.commit()
 
     async def _next_message_index(self, run_id: str) -> int:
         stmt = (

--- a/backend/app/worker/executor.py
+++ b/backend/app/worker/executor.py
@@ -128,6 +128,10 @@ class RunExecutor:
             if resume_ctx is not None and resume_ctx.mode in ("retry", "resume"):
                 step_index_base = (await service._max_step_index(run.id)) + 1
 
+            run_messages = None
+            if resume_ctx is not None:
+                run_messages = await service.load_run_messages(run.id)
+
             run.status = RunStatus.RUNNING
             await session.commit()
             await service._broadcast("run.started", run.id, {})
@@ -147,6 +151,7 @@ class RunExecutor:
                 input=run.input,
                 metadata=run.metadata_,
                 resume=resume_ctx,
+                run_messages=run_messages,
                 step_index_base=step_index_base,
                 emit=_emit,
             )

--- a/backend/tests/test_checkpoint_retention.py
+++ b/backend/tests/test_checkpoint_retention.py
@@ -1,0 +1,64 @@
+"""Checkpoint retention and message decoupling service tests."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from app.db.base import Base
+from app.db.session import SessionLocal, engine
+from app.events import get_event_bus
+from app.models import Checkpoint, Run
+from app.services.run_service import RunService
+
+
+@pytest.mark.asyncio
+async def test_prune_checkpoints_keeps_latest_human_and_pre_failure():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    bus = get_event_bus()
+    async with SessionLocal() as session:
+        service = RunService(session=session, bus=bus)
+        run = Run(
+            tenant_id="default",
+            agent_id="01AGENT",
+            adapter="echo",
+            input={"prompt": "x"},
+        )
+        session.add(run)
+        await session.commit()
+        await session.refresh(run)
+
+        for idx, state in enumerate(
+            [
+                {"graph_state": {"completed_nodes": ["a"], "reply": "one"}},
+                {
+                    "graph_state": {
+                        "completed_nodes": ["a", "b"],
+                        "reply": "two",
+                        "pending_human": "approve",
+                    }
+                },
+                {"graph_state": {"completed_nodes": ["a", "b", "c"], "reply": "three"}},
+            ]
+        ):
+            session.add(
+                Checkpoint(run_id=run.id, index=idx, label=f"cp-{idx}", state=state)
+            )
+        await session.commit()
+
+        await service._retain_latest_checkpoint(run.id, reason="pre_failure")
+        await service._prune_checkpoints(run.id, keep_index=2)
+
+        result = await session.execute(
+            select(Checkpoint)
+            .where(Checkpoint.run_id == run.id)
+            .order_by(Checkpoint.index)
+        )
+        kept = list(result.scalars().all())
+        kept_indexes = [cp.index for cp in kept]
+        assert kept_indexes == [1, 2]
+        assert kept[0].state["graph_state"]["pending_human"] == "approve"
+        assert kept[1].index == 2

--- a/backend/tests/test_langgraph_adapter.py
+++ b/backend/tests/test_langgraph_adapter.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from app.adapters.base import AdapterContext
-from app.adapters.langgraph_adapter import GraphSpec, LangGraphAdapter
+from app.adapters.langgraph_adapter import GraphSpec, LangGraphAdapter, _checkpoint_payload
 from app.adapters.tool_registry import get_tool, list_tools, register_tool, resolve_tools
 from app.models.run import RunStatus
 from app.runtime.resume_context import RunResumeContext
@@ -27,6 +27,25 @@ class _RecordingContext(AdapterContext):
 
     async def _emit(self, event_type: str, data: dict[str, Any]) -> None:
         self.events.append((event_type, data))
+
+
+def _run_messages_from_events(
+    events: list[tuple[str, dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for event, data in events:
+        if event != "message.created":
+            continue
+        msg: dict[str, Any] = {"role": data["role"], "content": data.get("content", "")}
+        if data.get("name"):
+            msg["name"] = data["name"]
+        if data.get("tool_call_id"):
+            msg["tool_call_id"] = data["tool_call_id"]
+        extra = data.get("extra") or {}
+        if extra.get("tool_calls"):
+            msg["tool_calls"] = extra["tool_calls"]
+        rows.append(msg)
+    return rows
 
 
 @pytest.mark.asyncio
@@ -277,6 +296,7 @@ async def test_langgraph_human_node_pauses_and_resumes():
     graph_state = checkpoints[-1]["state"]["graph_state"]
     assert graph_state["pending_human"] == "approve"
     assert "draft" in graph_state["completed_nodes"]
+    assert "messages" not in graph_state
 
     resume_ctx = _RecordingContext(
         resume=RunResumeContext(
@@ -284,6 +304,7 @@ async def test_langgraph_human_node_pauses_and_resumes():
             checkpoint_state={"graph_state": graph_state},
             human_input={"route": "approved", "note": "lgtm"},
         ),
+        run_messages=_run_messages_from_events(ctx.events),
         step_index_base=1,
     )
     resume_ctx.agent_config = ctx.agent_config
@@ -351,3 +372,18 @@ async def test_langgraph_conditional_reject_skips_finalize():
     ]
     assert step_nodes == ["approve"]
     assert result.output == {"reply": "[mock] draft"}
+
+
+def test_checkpoint_payload_omits_messages():
+    state = {
+        "input": "hello",
+        "messages": [{"role": "user", "content": "hello"}],
+        "reply": "done",
+        "completed_nodes": ["draft"],
+        "pending_human": "approve",
+    }
+    payload = _checkpoint_payload(state)
+    graph = payload["graph_state"]
+    assert graph["reply"] == "done"
+    assert graph["pending_human"] == "approve"
+    assert "messages" not in graph

--- a/backend/tests/test_tool_failure_recovery.py
+++ b/backend/tests/test_tool_failure_recovery.py
@@ -45,6 +45,23 @@ class _RecordingContext(AdapterContext):
         self.events.append((event_type, data))
 
 
+def _run_messages_from_events(
+    events: list[tuple[str, dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for event, data in events:
+        if event != "message.created":
+            continue
+        msg: dict[str, Any] = {"role": data["role"], "content": data.get("content", "")}
+        if data.get("tool_call_id"):
+            msg["tool_call_id"] = data["tool_call_id"]
+        extra = data.get("extra") or {}
+        if extra.get("tool_calls"):
+            msg["tool_calls"] = extra["tool_calls"]
+        rows.append(msg)
+    return rows
+
+
 def _agent_graph_config(**overrides: Any) -> dict[str, Any]:
     base: dict[str, Any] = {
         "model": "openai/gpt-4o-mini",
@@ -280,7 +297,9 @@ async def test_feedback_parallel_success_and_recoverable(monkeypatch: pytest.Mon
     checkpoints = [
         data for event, data in ctx.events if event == "checkpoint.created"
     ]
-    messages = checkpoints[-1]["state"]["graph_state"]["messages"]
+    graph_state = checkpoints[-1]["state"]["graph_state"]
+    assert "messages" not in graph_state
+    messages = _run_messages_from_events(ctx.events)
     tool_msgs = [
         (m["tool_call_id"], json.loads(m["content"]))
         for m in messages
@@ -423,8 +442,7 @@ async def test_provider_tool_call_id_paired_with_lifecycle_call_id():
         data for event, data in ctx.events if event == "checkpoint.created"
     ]
     tool_msgs = [
-        m for m in checkpoints[-1]["state"]["graph_state"]["messages"]
-        if m.get("role") == "tool"
+        m for m in _run_messages_from_events(ctx.events) if m.get("role") == "tool"
     ]
     assert started[0]["call_id"] == completed[0]["call_id"]
     assert len(started[0]["call_id"]) == 26


### PR DESCRIPTION
- Added `run_messages` to `AdapterContext` to store ordered chat history for retries and resumes.
- Updated `emit_message` method to include `tool_call_id` in the emitted message payload.
- Introduced `_checkpoint_payload` function to structure checkpoint state without including messages.
- Implemented `load_run_messages` in `RunService` to retrieve messages associated with a run.
- Enhanced `RunExecutor` to load messages during run resumption.
- Updated tests to verify message handling and checkpoint behavior.

These changes improve the management of message history and checkpoint states, enhancing the robustness of the LangGraphAdapter's functionality.
