### PR TITLE
feat: implement run message pagination and preview in API

### DIFF
--- a/backend-java/src/main/java/io/agentflow/api/controller/RunsController.java
+++ b/backend-java/src/main/java/io/agentflow/api/controller/RunsController.java
@@ -1,5 +1,6 @@
 package io.agentflow.api.controller;
 
+import io.agentflow.api.dto.MessagePageResponse;
 import io.agentflow.api.dto.RunCreateRequest;
 import io.agentflow.api.dto.RunResponse;
 import io.agentflow.api.dto.RunResumeRequest;
@@ -41,6 +42,14 @@ public class RunsController {
     @GetMapping("/{id}")
     public RunResponse get(@PathVariable String id) {
         return service.get(id);
+    }
+
+    @GetMapping("/{id}/messages")
+    public MessagePageResponse listMessages(
+            @PathVariable String id,
+            @RequestParam(required = false) Integer cursor,
+            @RequestParam(defaultValue = "50") int limit) {
+        return service.listMessages(id, cursor, limit);
     }
 
     @PostMapping("/{id}/cancel")

--- a/backend-java/src/main/java/io/agentflow/api/dto/MessagePageResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/MessagePageResponse.java
@@ -1,0 +1,31 @@
+package io.agentflow.api.dto;
+
+import java.util.List;
+
+public class MessagePageResponse {
+
+    private List<MessageResponse> items;
+    private Integer nextCursor;
+    private boolean hasMore;
+
+    public static MessagePageResponse of(
+            List<MessageResponse> items, Integer nextCursor, boolean hasMore) {
+        MessagePageResponse page = new MessagePageResponse();
+        page.items = items;
+        page.nextCursor = nextCursor;
+        page.hasMore = hasMore;
+        return page;
+    }
+
+    public List<MessageResponse> getItems() {
+        return items;
+    }
+
+    public Integer getNextCursor() {
+        return nextCursor;
+    }
+
+    public boolean isHasMore() {
+        return hasMore;
+    }
+}

--- a/backend-java/src/main/java/io/agentflow/api/dto/RunResponse.java
+++ b/backend-java/src/main/java/io/agentflow/api/dto/RunResponse.java
@@ -20,6 +20,7 @@ public class RunResponse {
     private Instant updatedAt;
     private List<StepResponse> steps;
     private List<MessageResponse> messages;
+    private boolean messagesTruncated;
     private List<CheckpointResponse> checkpoints;
     private RunUsage usage = RunUsage.empty();
 
@@ -35,19 +36,38 @@ public class RunResponse {
             List<StepResponse> steps,
             List<MessageResponse> messages,
             List<CheckpointResponse> checkpoints) {
-        RunUsage usage = steps.isEmpty()
-                ? RunUsage.fromMetadata(entity.getMetadata())
-                : RunUsage.fromSteps(steps);
-        if (usage == null) {
-            usage = RunUsage.empty();
-        }
-        return fromEntity(entity, steps, messages, checkpoints, usage);
+        return fromEntity(entity, steps, messages, false, checkpoints);
     }
 
     public static RunResponse fromEntity(
             RunEntity entity,
             List<StepResponse> steps,
             List<MessageResponse> messages,
+            boolean messagesTruncated,
+            List<CheckpointResponse> checkpoints) {
+        RunUsage usage = steps.isEmpty()
+                ? RunUsage.fromMetadata(entity.getMetadata())
+                : RunUsage.fromSteps(steps);
+        if (usage == null) {
+            usage = RunUsage.empty();
+        }
+        return fromEntity(entity, steps, messages, messagesTruncated, checkpoints, usage);
+    }
+
+    public static RunResponse fromEntity(
+            RunEntity entity,
+            List<StepResponse> steps,
+            List<MessageResponse> messages,
+            List<CheckpointResponse> checkpoints,
+            RunUsage usage) {
+        return fromEntity(entity, steps, messages, false, checkpoints, usage);
+    }
+
+    public static RunResponse fromEntity(
+            RunEntity entity,
+            List<StepResponse> steps,
+            List<MessageResponse> messages,
+            boolean messagesTruncated,
             List<CheckpointResponse> checkpoints,
             RunUsage usage) {
         RunResponse dto = new RunResponse();
@@ -63,6 +83,7 @@ public class RunResponse {
         dto.updatedAt = entity.getUpdatedAt();
         dto.steps = steps;
         dto.messages = messages;
+        dto.messagesTruncated = messagesTruncated;
         dto.checkpoints = checkpoints;
         dto.usage = usage;
         return dto;
@@ -114,6 +135,10 @@ public class RunResponse {
 
     public List<MessageResponse> getMessages() {
         return messages;
+    }
+
+    public boolean isMessagesTruncated() {
+        return messagesTruncated;
     }
 
     public List<CheckpointResponse> getCheckpoints() {

--- a/backend-java/src/main/java/io/agentflow/api/repository/MessageRepository.java
+++ b/backend-java/src/main/java/io/agentflow/api/repository/MessageRepository.java
@@ -2,9 +2,15 @@ package io.agentflow.api.repository;
 
 import io.agentflow.api.entity.MessageEntity;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageRepository extends JpaRepository<MessageEntity, String> {
 
     List<MessageEntity> findAllByRunIdOrderByIndexAsc(String runId);
+
+    List<MessageEntity> findByRunIdOrderByIndexDesc(String runId, Pageable pageable);
+
+    List<MessageEntity> findByRunIdAndIndexLessThanOrderByIndexDesc(
+            String runId, int index, Pageable pageable);
 }

--- a/backend-java/src/main/java/io/agentflow/api/service/MessagePagination.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/MessagePagination.java
@@ -1,0 +1,10 @@
+package io.agentflow.api.service;
+
+/** Shared limits for run message preview and cursor pages. */
+public final class MessagePagination {
+
+    public static final int PREVIEW_LIMIT = 50;
+    public static final int PAGE_MAX = 200;
+
+    private MessagePagination() {}
+}

--- a/backend-java/src/main/java/io/agentflow/api/service/RunService.java
+++ b/backend-java/src/main/java/io/agentflow/api/service/RunService.java
@@ -1,6 +1,7 @@
 package io.agentflow.api.service;
 
 import io.agentflow.api.dto.CheckpointResponse;
+import io.agentflow.api.dto.MessagePageResponse;
 import io.agentflow.api.dto.MessageResponse;
 import io.agentflow.api.dto.RunCreateRequest;
 import io.agentflow.api.dto.RunResponse;
@@ -10,6 +11,7 @@ import io.agentflow.api.entity.CheckpointEntity;
 import io.agentflow.api.dto.StepResponse;
 import io.agentflow.api.dto.ToolCallResponse;
 import io.agentflow.api.entity.AgentEntity;
+import io.agentflow.api.entity.MessageEntity;
 import io.agentflow.api.entity.RunEntity;
 import io.agentflow.api.entity.RunStatus;
 import io.agentflow.api.entity.StepEntity;
@@ -24,6 +26,7 @@ import io.agentflow.api.repository.ToolCallRepository;
 import io.agentflow.api.security.AccessControl;
 import io.agentflow.api.security.Role;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,6 +148,14 @@ public class RunService {
         return toResponse(requireRun(id, Role.VIEWER));
     }
 
+    @Transactional(readOnly = true)
+    public MessagePageResponse listMessages(String id, Integer cursor, int limit) {
+        RunEntity run = requireRun(id, Role.VIEWER);
+        int capped = Math.max(1, Math.min(limit, MessagePagination.PAGE_MAX));
+        MessagePage page = fetchMessagePage(run.getId(), cursor, capped);
+        return MessagePageResponse.of(page.items(), page.nextCursor(), page.hasMore());
+    }
+
     /** Ensure the run exists in the caller's tenant (for SSE and cross-service checks). */
     @Transactional(readOnly = true)
     public void requireAccessible(String id) {
@@ -260,14 +271,47 @@ public class RunService {
         List<StepResponse> stepDtos = stepEntities.stream()
                 .map(s -> StepResponse.fromEntity(s, toolsByStep.getOrDefault(s.getId(), List.of())))
                 .toList();
-        List<MessageResponse> messageDtos = messages.findAllByRunIdOrderByIndexAsc(run.getId())
-                .stream()
-                .map(MessageResponse::fromEntity)
-                .toList();
+        List<MessageResponse> messageDtos;
+        boolean messagesTruncated;
+        if (MessagePagination.PREVIEW_LIMIT <= 0) {
+            messageDtos = List.of();
+            MessagePage probe = fetchMessagePage(run.getId(), null, 1);
+            messagesTruncated = !probe.items().isEmpty();
+        } else {
+            MessagePage preview = fetchMessagePage(
+                    run.getId(), null, MessagePagination.PREVIEW_LIMIT);
+            messageDtos = preview.items();
+            messagesTruncated = preview.hasMore();
+        }
         List<CheckpointResponse> checkpointDtos = checkpoints.findAllByRunIdOrderByIndexAsc(run.getId())
                 .stream()
                 .map(CheckpointResponse::fromEntity)
                 .toList();
-        return RunResponse.fromEntity(run, stepDtos, messageDtos, checkpointDtos);
+        return RunResponse.fromEntity(
+                run, stepDtos, messageDtos, messagesTruncated, checkpointDtos);
     }
+
+    private MessagePage fetchMessagePage(String runId, Integer cursor, int limit) {
+        List<MessageEntity> rows;
+        if (cursor == null) {
+            rows = new ArrayList<>(
+                    messages.findByRunIdOrderByIndexDesc(runId, PageRequest.of(0, limit + 1)));
+        } else {
+            rows = new ArrayList<>(messages.findByRunIdAndIndexLessThanOrderByIndexDesc(
+                    runId, cursor, PageRequest.of(0, limit + 1)));
+        }
+        boolean hasMore = rows.size() > limit;
+        if (hasMore) {
+            rows = rows.subList(0, limit);
+        }
+        Collections.reverse(rows);
+        List<MessageResponse> items = rows.stream()
+                .map(MessageResponse::fromEntity)
+                .toList();
+        Integer nextCursor = !items.isEmpty() && hasMore ? items.getFirst().getIndex() : null;
+        return new MessagePage(items, nextCursor, hasMore);
+    }
+
+    private record MessagePage(
+            List<MessageResponse> items, Integer nextCursor, boolean hasMore) {}
 }

--- a/backend/app/api/v1/runs.py
+++ b/backend/app/api/v1/runs.py
@@ -4,7 +4,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import AuthPrincipal, Role, require_role
 from app.db.session import get_session
 from app.events import EventBus, get_event_bus
-from app.schemas.run import RunCreate, RunRead, RunResume, RunRetry, run_read_from_orm
+from app.schemas.run import (
+    MessagePage,
+    RunCreate,
+    RunRead,
+    RunResume,
+    RunRetry,
+    run_read_from_orm,
+)
 from app.services.run_service import (
     AgentNotFound,
     RunConflict,
@@ -20,6 +27,27 @@ def get_run_service(
     bus: EventBus = Depends(get_event_bus),
 ) -> RunService:
     return RunService(session=session, bus=bus)
+
+
+async def _run_read(
+    service: RunService,
+    run_id: str,
+    principal: AuthPrincipal,
+) -> RunRead:
+    run = await service.get_run(
+        run_id,
+        with_relations=True,
+        tenant_id=principal.tenant_id,
+        project_id=principal.project_id,
+        agent_id=principal.agent_id,
+    )
+    truncated = await service.hydrate_run_messages(
+        run,
+        tenant_id=principal.tenant_id,
+        project_id=principal.project_id,
+        agent_id=principal.agent_id,
+    )
+    return run_read_from_orm(run, messages_truncated=truncated)
 
 
 @router.post("", response_model=RunRead, status_code=status.HTTP_202_ACCEPTED)
@@ -39,14 +67,10 @@ async def create_run(
         raise HTTPException(status_code=404, detail=f"Agent not found: {exc}") from exc
 
     await service.start_run(run.id)
-    run = await service.get_run(
-        run.id,
-        with_relations=True,
-        tenant_id=principal.tenant_id,
-        project_id=principal.project_id,
-        agent_id=principal.agent_id,
-    )
-    return run_read_from_orm(run)
+    try:
+        return await _run_read(service, run.id, principal)
+    except RunNotFound as exc:
+        raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
 
 
 @router.get("", response_model=list[RunRead])
@@ -71,16 +95,30 @@ async def get_run(
     principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
 ) -> RunRead:
     try:
-        run = await service.get_run(
+        return await _run_read(service, run_id, principal)
+    except RunNotFound as exc:
+        raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
+
+
+@router.get("/{run_id}/messages", response_model=MessagePage)
+async def list_run_messages(
+    run_id: str,
+    cursor: int | None = None,
+    limit: int = 50,
+    service: RunService = Depends(get_run_service),
+    principal: AuthPrincipal = Depends(require_role(Role.VIEWER)),
+) -> MessagePage:
+    try:
+        return await service.list_messages(
             run_id,
-            with_relations=True,
+            cursor=cursor,
+            limit=limit,
             tenant_id=principal.tenant_id,
             project_id=principal.project_id,
             agent_id=principal.agent_id,
         )
     except RunNotFound as exc:
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
-    return run_read_from_orm(run)
 
 
 @router.post("/{run_id}/cancel", status_code=status.HTTP_204_NO_CONTENT)
@@ -106,7 +144,7 @@ async def retry_run(
     principal: AuthPrincipal = Depends(require_role(Role.OPERATOR)),
 ) -> RunRead:
     try:
-        run = await service.retry_run(
+        await service.retry_run(
             run_id, payload, tenant_id=principal.tenant_id,
             project_id=principal.project_id, agent_id=principal.agent_id,
         )
@@ -114,7 +152,7 @@ async def retry_run(
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
     except RunConflict as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return run_read_from_orm(run)
+    return await _run_read(service, run_id, principal)
 
 
 @router.post("/{run_id}/resume", response_model=RunRead, status_code=status.HTTP_202_ACCEPTED)
@@ -125,7 +163,7 @@ async def resume_run(
     principal: AuthPrincipal = Depends(require_role(Role.OPERATOR)),
 ) -> RunRead:
     try:
-        run = await service.resume_run(
+        await service.resume_run(
             run_id, payload, tenant_id=principal.tenant_id,
             project_id=principal.project_id, agent_id=principal.agent_id,
         )
@@ -133,4 +171,4 @@ async def resume_run(
         raise HTTPException(status_code=404, detail=f"Run not found: {exc}") from exc
     except RunConflict as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return run_read_from_orm(run)
+    return await _run_read(service, run_id, principal)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -257,6 +257,22 @@ class Settings(BaseSettings):
         description="Periodic metric reader export interval in milliseconds.",
     )
 
+    run_messages_preview_limit: int = Field(
+        default=50,
+        ge=0,
+        le=500,
+        description=(
+            "Maximum messages embedded in GET /v1/runs/{id} (most recent). "
+            "Use GET /v1/runs/{id}/messages for older pages."
+        ),
+    )
+    run_messages_page_max: int = Field(
+        default=200,
+        ge=1,
+        le=500,
+        description="Upper bound for limit on GET /v1/runs/{id}/messages.",
+    )
+
 
 def effective_jobs_impl(settings: Settings | None = None) -> JobsImpl:
     """Resolve the job protocol Java and Python must agree on."""

--- a/backend/app/schemas/run.py
+++ b/backend/app/schemas/run.py
@@ -55,6 +55,17 @@ class MessageRead(BaseModel):
     created_at: datetime
 
 
+class MessagePage(BaseModel):
+    """Cursor page of run messages in ascending index order."""
+
+    items: list[MessageRead]
+    next_cursor: int | None = Field(
+        default=None,
+        description="Pass as cursor to fetch older messages (index exclusive).",
+    )
+    has_more: bool = False
+
+
 class StepRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -99,6 +110,7 @@ class RunRead(BaseModel):
     updated_at: datetime
     steps: list[StepRead] = []
     messages: list[MessageRead] = []
+    messages_truncated: bool = False
     checkpoints: list[CheckpointRead] = []
     usage: RunUsage = Field(default_factory=RunUsage)
 
@@ -109,14 +121,25 @@ class RunRead(BaseModel):
         return self
 
 
-def run_read_from_orm(run: Run) -> RunRead:
+def run_read_from_orm(
+    run: Run,
+    *,
+    messages_truncated: bool = False,
+) -> RunRead:
     """Build API run DTO with usage from steps or persisted metadata."""
     dto = RunRead.model_validate(run)
+    updates: dict[str, Any] = {}
+    if messages_truncated:
+        updates["messages_truncated"] = True
     if dto.steps:
+        if updates:
+            return dto.model_copy(update=updates)
         return dto
     stored = usage_from_metadata(run.metadata_)
     if stored is not None:
-        return dto.model_copy(update={"usage": stored})
+        updates["usage"] = stored
+    if updates:
+        return dto.model_copy(update=updates)
     return dto
 
 

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -14,7 +14,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import selectinload, attributes
 
 from app.adapters import get_adapter
 from app.core.config import get_settings, jobs_backend
@@ -38,7 +38,7 @@ from app.core.telemetry import (
 )
 from app.runtime.messages import messages_from_rows
 from app.runtime.usage import aggregate_run_usage
-from app.schemas.run import EventType, RunCreate, RunEvent, RunResume, RunRetry
+from app.schemas.run import EventType, MessagePage, MessageRead, RunCreate, RunEvent, RunResume, RunRetry
 from app.runtime.resume_context import (
     RunResumeContext,
     parse_resume_context,
@@ -365,7 +365,6 @@ class RunService:
         if with_relations:
             stmt = stmt.options(
                 selectinload(Run.steps).selectinload(Step.tool_calls),
-                selectinload(Run.messages),
                 selectinload(Run.checkpoints),
             )
         try:
@@ -636,6 +635,76 @@ class RunService:
         )
         result = await self.session.execute(stmt)
         return messages_from_rows(list(result.scalars().all()))
+
+    async def list_messages(
+        self,
+        run_id: str,
+        *,
+        cursor: int | None = None,
+        limit: int = 50,
+        tenant_id: str | None = None,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+        require_access: bool = True,
+    ) -> MessagePage:
+        """Return a page of messages in ascending index order (newest page first)."""
+        if require_access:
+            await self._get_run(
+                run_id,
+                tenant_id=tenant_id,
+                project_id=project_id,
+                agent_id=agent_id,
+            )
+
+        capped = max(1, min(limit, get_settings().run_messages_page_max))
+        rows, has_more, next_cursor = await self._fetch_message_page(
+            run_id, cursor=cursor, limit=capped
+        )
+        items = [MessageRead.model_validate(row) for row in rows]
+        return MessagePage(items=items, next_cursor=next_cursor, has_more=has_more)
+
+    async def hydrate_run_messages(
+        self,
+        run: Run,
+        *,
+        tenant_id: str | None = None,
+        project_id: str | None = None,
+        agent_id: str | None = None,
+    ) -> bool:
+        """Attach a message preview to ``run``; return whether older rows exist."""
+        preview_limit = get_settings().run_messages_preview_limit
+        if preview_limit <= 0:
+            attributes.set_committed_value(run, "messages", [])
+            rows, _, _ = await self._fetch_message_page(run.id, limit=1)
+            return bool(rows)
+
+        rows, has_more, _ = await self._fetch_message_page(
+            run.id, limit=preview_limit
+        )
+        attributes.set_committed_value(run, "messages", rows)
+        return has_more
+
+    async def _fetch_message_page(
+        self,
+        run_id: str,
+        *,
+        cursor: int | None = None,
+        limit: int,
+    ) -> tuple[list[Message], bool, int | None]:
+        stmt = select(Message).where(Message.run_id == run_id)
+        if cursor is not None:
+            stmt = stmt.where(Message.index < cursor)
+        stmt = stmt.order_by(Message.index.desc()).limit(limit + 1)
+
+        result = await self.session.execute(stmt)
+        rows = list(result.scalars().all())
+        has_more = len(rows) > limit
+        if has_more:
+            rows = rows[:limit]
+        rows.reverse()
+
+        next_cursor = rows[0].index if rows and has_more else None
+        return rows, has_more, next_cursor
 
     async def _retain_latest_checkpoint(
         self, run_id: str, *, reason: str

--- a/backend/tests/test_runs.py
+++ b/backend/tests/test_runs.py
@@ -130,3 +130,71 @@ async def test_retry_conflict_when_not_failed(client):
 
     retry = await client.post(f"/v1/runs/{run_id}/retry")
     assert retry.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_run_messages_preview_and_pagination(client):
+    from sqlalchemy import delete
+
+    from app.db.session import SessionLocal
+    from app.models import Message
+
+    create = await client.post(
+        "/v1/agents",
+        json={"name": "msg-bot", "adapter": "echo", "config": {"delay": 0}},
+    )
+    agent_id = create.json()["id"]
+    run_response = await client.post(
+        "/v1/runs",
+        json={"agent_id": agent_id, "input": {"prompt": "seed"}},
+    )
+    run_id = run_response.json()["id"]
+    await _poll_until(client, run_id, {"succeeded"})
+
+    async with SessionLocal() as session:
+        await session.execute(delete(Message).where(Message.run_id == run_id))
+        await session.commit()
+        for index in range(60):
+            session.add(
+                Message(
+                    run_id=run_id,
+                    index=index,
+                    role="user",
+                    content=f"message-{index}",
+                )
+            )
+        await session.commit()
+
+    detail = await client.get(f"/v1/runs/{run_id}")
+    assert detail.status_code == 200, detail.text
+    body = detail.json()
+    assert len(body["messages"]) == 50
+    assert body["messages_truncated"] is True
+    assert body["messages"][0]["index"] == 10
+    assert body["messages"][-1]["index"] == 59
+
+    latest = await client.get(f"/v1/runs/{run_id}/messages?limit=10")
+    assert latest.status_code == 200, latest.text
+    page = latest.json()
+    assert len(page["items"]) == 10
+    assert page["items"][0]["index"] == 50
+    assert page["items"][-1]["index"] == 59
+    assert page["has_more"] is True
+    assert page["next_cursor"] == 50
+
+    older = await client.get(f"/v1/runs/{run_id}/messages?cursor=50&limit=20")
+    assert older.status_code == 200, older.text
+    older_page = older.json()
+    assert len(older_page["items"]) == 20
+    assert older_page["items"][0]["index"] == 30
+    assert older_page["items"][-1]["index"] == 49
+    assert older_page["has_more"] is True
+
+    oldest = await client.get(f"/v1/runs/{run_id}/messages?cursor=30&limit=50")
+    assert oldest.status_code == 200, oldest.text
+    oldest_page = oldest.json()
+    assert len(oldest_page["items"]) == 30
+    assert oldest_page["items"][0]["index"] == 0
+    assert oldest_page["items"][-1]["index"] == 29
+    assert oldest_page["has_more"] is False
+    assert oldest_page["next_cursor"] is None

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -158,8 +158,29 @@ sensible upper bound on the server (default 50).
 
 ### `GET /v1/runs/{id}` → 200
 
-Response: a `Run` populated with `steps`, `messages`, and `checkpoints`.
-404 if missing.
+Response: a `Run` populated with `steps`, a **preview** of `messages` (most
+recent *K*, default 50), and `checkpoints`. When older messages exist,
+`messages_truncated` is `true`; use `GET /v1/runs/{id}/messages` to page
+backward. 404 if missing.
+
+### `GET /v1/runs/{id}/messages?cursor=&limit=50` → 200
+
+Cursor-paginated run transcript in ascending `index` order. Omit `cursor` to
+fetch the newest page; pass `next_cursor` from a prior response to load older
+messages (`index` exclusive upper bound). `limit` clamps on the server
+(default 50, max 200).
+
+Response:
+
+```json
+{
+  "items": [/* Message */],
+  "next_cursor": 12,
+  "has_more": true
+}
+```
+
+404 if the run does not exist.
 
 ### `POST /v1/runs/{id}/cancel` → 204
 
@@ -413,6 +434,7 @@ is disabled). Agent `name` is unique **per tenant**.
   updated_at: string;
   steps: Step[];
   messages: Message[];
+  messages_truncated?: boolean;
   checkpoints: Checkpoint[];
   usage: RunUsage;
 }
@@ -473,6 +495,16 @@ ops dashboards.
   tool_call_id: string | null;
   extra: Record<string, unknown>;
   created_at: string;
+}
+```
+
+### `MessagePage`
+
+```ts
+{
+  items: Message[];
+  next_cursor: number | null;
+  has_more: boolean;
 }
 ```
 

--- a/frontend/app/runs/[id]/page.tsx
+++ b/frontend/app/runs/[id]/page.tsx
@@ -6,6 +6,7 @@ import { use } from "react";
 
 import { CheckpointPanel } from "@/components/CheckpointPanel";
 import { EventStream } from "@/components/EventStream";
+import { MessagesPanel } from "@/components/MessagesPanel";
 import { StatusBadge } from "@/components/StatusBadge";
 import { StepTimeline } from "@/components/StepTimeline";
 import { TokenCostSummary } from "@/components/TokenCostSummary";
@@ -108,23 +109,11 @@ export default function RunDetailPage({ params }: PageProps) {
 
       <ToolCallPanel steps={r.steps} />
 
-      <section className="space-y-3">
-        <h2 className="font-medium">Messages</h2>
-        <ol className="space-y-2">
-          {r.messages.map((m) => (
-            <li
-              key={m.id}
-              className="rounded border border-border bg-surface p-3 text-sm"
-            >
-              <div className="text-xs uppercase tracking-wide text-muted mb-1">
-                {m.role}
-                {m.name ? ` · ${m.name}` : ""}
-              </div>
-              <div className="whitespace-pre-wrap">{m.content}</div>
-            </li>
-          ))}
-        </ol>
-      </section>
+      <MessagesPanel
+        runId={id}
+        messages={r.messages}
+        messagesTruncated={r.messages_truncated ?? false}
+      />
 
       <EventStream events={run.events} status={run.streamStatus} />
     </div>

--- a/frontend/components/MessagesPanel.tsx
+++ b/frontend/components/MessagesPanel.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { api } from "@/lib/api";
+import type { Message } from "@/lib/types";
+
+interface MessagesPanelProps {
+  runId: string;
+  messages: Message[];
+  messagesTruncated: boolean;
+}
+
+function mergeMessages(...groups: Message[][]): Message[] {
+  const byIndex = new Map<number, Message>();
+  for (const group of groups) {
+    for (const message of group) {
+      byIndex.set(message.index, message);
+    }
+  }
+  return [...byIndex.values()].sort((a, b) => a.index - b.index);
+}
+
+export function MessagesPanel({
+  runId,
+  messages,
+  messagesTruncated,
+}: MessagesPanelProps) {
+  const [older, setOlder] = useState<Message[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [hasMore, setHasMore] = useState(messagesTruncated);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setOlder([]);
+    setNextCursor(null);
+    setHasMore(messagesTruncated);
+  }, [runId, messagesTruncated]);
+
+  const displayed = useMemo(
+    () => mergeMessages(older, messages),
+    [older, messages],
+  );
+
+  async function loadOlder() {
+    if (loading || !hasMore) return;
+    const cursor = nextCursor ?? displayed[0]?.index;
+    if (cursor == null) return;
+
+    setLoading(true);
+    try {
+      const page = await api.listRunMessages(runId, { cursor, limit: 50 });
+      setOlder((prev) => mergeMessages(page.items, prev));
+      setNextCursor(page.next_cursor);
+      setHasMore(page.has_more);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-medium">Messages</h2>
+        {displayed.length > 0 ? (
+          <span className="text-xs text-muted">
+            {displayed.length} shown
+            {hasMore ? " · older available" : ""}
+          </span>
+        ) : null}
+      </div>
+
+      {hasMore ? (
+        <button
+          type="button"
+          className="rounded border border-border px-3 py-1.5 text-sm hover:bg-surface disabled:opacity-50"
+          onClick={() => void loadOlder()}
+          disabled={loading}
+        >
+          {loading ? "Loading…" : "Load older messages"}
+        </button>
+      ) : null}
+
+      <ol className="max-h-[32rem] space-y-2 overflow-y-auto pr-1">
+        {displayed.map((message) => (
+          <li
+            key={message.id}
+            className="rounded border border-border bg-surface p-3 text-sm"
+          >
+            <div className="mb-1 text-xs uppercase tracking-wide text-muted">
+              {message.role}
+              {message.name ? ` · ${message.name}` : ""}
+              <span className="ml-2 font-mono normal-case">#{message.index}</span>
+            </div>
+            <div className="whitespace-pre-wrap">{message.content}</div>
+          </li>
+        ))}
+      </ol>
+
+      {displayed.length === 0 ? (
+        <p className="text-sm text-muted">No messages yet.</p>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Agent, AgentVersion, AgentVersionDiff, Run } from "./types";
+import type { Agent, AgentVersion, AgentVersionDiff, MessagePage, Run } from "./types";
 import { normalizeUsage } from "./usage";
 
 function authHeaders(): Record<string, string> {
@@ -35,6 +35,22 @@ export const api = {
     return runs.map(normalizeRun);
   },
   getRun: async (id: string) => normalizeRun(await request<Run>(`/v1/runs/${id}`)),
+  listRunMessages: async (
+    id: string,
+    params?: { cursor?: number; limit?: number },
+  ) => {
+    const search = new URLSearchParams();
+    if (params?.cursor != null) {
+      search.set("cursor", String(params.cursor));
+    }
+    if (params?.limit != null) {
+      search.set("limit", String(params.limit));
+    }
+    const query = search.toString();
+    return request<MessagePage>(
+      `/v1/runs/${id}/messages${query ? `?${query}` : ""}`,
+    );
+  },
   cancelRun: (id: string) =>
     request<void>(`/v1/runs/${id}/cancel`, { method: "POST" }),
   retryRun: async (id: string, body?: { checkpoint_index?: number }) =>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -54,6 +54,12 @@ export interface Message {
   created_at: string;
 }
 
+export interface MessagePage {
+  items: Message[];
+  next_cursor: number | null;
+  has_more: boolean;
+}
+
 export interface Checkpoint {
   id: string;
   index: number;
@@ -74,6 +80,7 @@ export interface Run {
   updated_at: string;
   steps: Step[];
   messages: Message[];
+  messages_truncated?: boolean;
   checkpoints: Checkpoint[];
   usage: RunUsage;
 }


### PR DESCRIPTION
- Added a new endpoint to retrieve paginated messages for a run, allowing clients to fetch older messages using a cursor.
- Enhanced the existing run retrieval endpoint to include a preview of the most recent messages, indicating if more messages are available.
- Introduced new configuration options for message limits in the settings.
- Updated the run schema to include a flag for message truncation.
- Implemented frontend components to display messages and handle pagination.

These changes improve the user experience by providing efficient access to run messages and enhancing the overall functionality of the API.
