### PR TITLE
feat: stream and persist reasoning blocks

### DIFF
--- a/backend/app/adapters/base.py
+++ b/backend/app/adapters/base.py
@@ -99,12 +99,25 @@ class AdapterContext:
         step_index: int,
         delta: str,
         role: str = "assistant",
+        part: str = "text",
         **data: Any,
     ) -> None:
-        """Stream an incremental token chunk to SSE subscribers (no DB write)."""
+        """Stream an incremental token chunk to SSE subscribers (no DB write).
+
+        ``part`` discriminates fine-grained streams: ``text`` (default) for the
+        visible reply, ``reasoning`` for model thinking / chain-of-thought.
+        Reasoning deltas are still ephemeral; persist the finished block with
+        ``emit_message(..., kind="reasoning")``.
+        """
         await self.emit(
             "token.delta",
-            {"step_index": step_index, "delta": delta, "role": role, **data},
+            {
+                "step_index": step_index,
+                "delta": delta,
+                "role": role,
+                "part": part,
+                **data,
+            },
         )
 
     async def emit_message(

--- a/backend/app/adapters/langgraph_adapter.py
+++ b/backend/app/adapters/langgraph_adapter.py
@@ -12,6 +12,7 @@ Expected agent.config shape (all optional except when using custom graphs):
   "model": "openai/gpt-4o-mini",
   "system_prompt": "You are a helpful coordinator.",
   "stream_tokens": true,       // emit token.delta SSE; defer tokens to step.updated
+  "stream_reasoning": false,   // mock / providers: also stream part=reasoning blocks
   "tools": ["echo"],           // builtin or MCP keys (mcp/{server}/{tool})
   "mcp_servers": [             // optional MCP stdio/SSE/HTTP servers
     {
@@ -141,6 +142,7 @@ class WaitingHumanInterrupt(Exception):
 @dataclass
 class ModelResponse:
     content: str
+    reasoning: str = ""
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     tokens_in: int = 0
     tokens_out: int = 0
@@ -575,6 +577,7 @@ class LangGraphAdapter(OrchestratorAdapter):
             total_in = 0
             total_out = 0
             final_reply = ""
+            final_reasoning = ""
             had_recoverable_feedback = False
             policy = run_state.tool_error_policy
 
@@ -673,6 +676,7 @@ class LangGraphAdapter(OrchestratorAdapter):
                         continue
 
                     final_reply = response.content or ""
+                    final_reasoning = response.reasoning or ""
                     messages.append({"role": "assistant", "content": final_reply})
                     break
                 else:
@@ -686,7 +690,12 @@ class LangGraphAdapter(OrchestratorAdapter):
 
                 latency_ms = int((time.monotonic() - started) * 1000)
                 cost_usd = estimate_cost_usd(model, total_in, total_out)
-                await ctx.emit_message(role="assistant", content=final_reply, step_index=step_idx)
+                await _emit_assistant_messages(
+                    ctx,
+                    step_index=step_idx,
+                    content=final_reply,
+                    reasoning=final_reasoning,
+                )
                 await ctx.emit_step_updated(
                     index=step_idx,
                     tokens_in=total_in,
@@ -791,7 +800,12 @@ class LangGraphAdapter(OrchestratorAdapter):
                 cost_usd=cost_usd,
                 latency_ms=latency_ms,
             )
-            await ctx.emit_message(role="assistant", content=reply, step_index=step_idx)
+            await _emit_assistant_messages(
+                ctx,
+                step_index=step_idx,
+                content=reply,
+                reasoning=response.reasoning,
+            )
             await ctx.emit_step_completed(
                 index=step_idx,
                 node=spec.id,
@@ -890,6 +904,7 @@ class LangGraphAdapter(OrchestratorAdapter):
             message = data["choices"][0]["message"]
             tool_calls = _parse_openai_tool_calls(message.get("tool_calls"))
             content = message.get("content") or ""
+            reasoning = _extract_reasoning_text(message)
             usage = data.get("usage") or {}
             prompt_text = json.dumps(messages, default=str)
             tokens_in = int(
@@ -897,10 +912,15 @@ class LangGraphAdapter(OrchestratorAdapter):
             )
             tokens_out = int(
                 usage.get("completion_tokens")
-                or estimate_tokens(content or json.dumps(tool_calls, default=str))
+                or estimate_tokens(
+                    (content or "")
+                    + reasoning
+                    + (json.dumps(tool_calls, default=str) if tool_calls else "")
+                )
             )
             return ModelResponse(
                 content=content,
+                reasoning=reasoning,
                 tool_calls=tool_calls,
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
@@ -956,12 +976,24 @@ class LangGraphAdapter(OrchestratorAdapter):
         else:
             reply = f"[mock:{model}]{suffix} {user_input}"
         tokens_in = estimate_tokens(json.dumps(messages, default=str))
-        tokens_out = estimate_tokens(reply)
+        reasoning = ""
+        if bool(ctx.agent_config.get("stream_reasoning")):
+            preview = user_input[:48].replace("\n", " ")
+            reasoning = f"[think:{model}] weigh options for: {preview}"
+        tokens_out = estimate_tokens(reply + reasoning)
         if stream_tokens:
+            if reasoning:
+                for chunk in _chunk_text(reasoning):
+                    await ctx.emit_token_delta(
+                        step_index=step_index, delta=chunk, part="reasoning"
+                    )
             for chunk in _chunk_text(reply):
-                await ctx.emit_token_delta(step_index=step_index, delta=chunk)
+                await ctx.emit_token_delta(
+                    step_index=step_index, delta=chunk, part="text"
+                )
         return ModelResponse(
             content=reply,
+            reasoning=reasoning,
             tokens_in=tokens_in,
             tokens_out=tokens_out,
         )
@@ -981,6 +1013,7 @@ class LangGraphAdapter(OrchestratorAdapter):
             "stream_options": {"include_usage": True},
         }
         parts: list[str] = []
+        reasoning_parts: list[str] = []
         tokens_in = 0
         tokens_out = 0
 
@@ -1010,20 +1043,34 @@ class LangGraphAdapter(OrchestratorAdapter):
                         )
                     for choice in chunk.get("choices") or []:
                         delta = choice.get("delta") or {}
+                        reasoning_piece = _extract_reasoning_text(delta)
+                        if reasoning_piece:
+                            reasoning_parts.append(reasoning_piece)
+                            await ctx.emit_token_delta(
+                                step_index=step_index,
+                                delta=reasoning_piece,
+                                part="reasoning",
+                            )
                         content = delta.get("content")
                         if content:
                             parts.append(content)
                             await ctx.emit_token_delta(
-                                step_index=step_index, delta=content
+                                step_index=step_index,
+                                delta=content,
+                                part="text",
                             )
 
         reply = "".join(parts)
+        reasoning = "".join(reasoning_parts)
         if not tokens_in:
             tokens_in = estimate_tokens(str(payload.get("messages", "")))
         if not tokens_out:
-            tokens_out = estimate_tokens(reply)
+            tokens_out = estimate_tokens(reply + reasoning)
         return ModelResponse(
-            content=reply, tokens_in=tokens_in, tokens_out=tokens_out
+            content=reply,
+            reasoning=reasoning,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
         )
 
 
@@ -1216,3 +1263,36 @@ def _initial_graph_state(ctx: AdapterContext) -> dict[str, Any]:
 def _chunk_text(text: str, *, size: int = 8) -> list[str]:
     """Split text into small chunks for mock streaming."""
     return [text[i : i + size] for i in range(0, len(text), size)] or [text]
+
+
+def _extract_reasoning_text(payload: dict[str, Any] | None) -> str:
+    """Pull reasoning / thinking text from OpenAI-compatible message or delta.
+
+    Providers disagree on the field name (``reasoning_content``, ``reasoning``,
+    Anthropic-style ``thinking``). Empty / missing values are ignored.
+    """
+    if not payload:
+        return ""
+    for key in ("reasoning_content", "reasoning", "thinking"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+async def _emit_assistant_messages(
+    ctx: AdapterContext,
+    *,
+    step_index: int,
+    content: str,
+    reasoning: str = "",
+) -> None:
+    """Persist optional reasoning block, then the visible assistant reply."""
+    if reasoning.strip():
+        await ctx.emit_message(
+            role="assistant",
+            content=reasoning,
+            step_index=step_index,
+            kind="reasoning",
+        )
+    await ctx.emit_message(role="assistant", content=content, step_index=step_index)

--- a/backend/app/services/thread_service.py
+++ b/backend/app/services/thread_service.py
@@ -217,9 +217,11 @@ class ThreadService:
     ) -> list[dict[str, Any]]:
         """Return OpenAI-style chat dicts for prior thread turns, window-trimmed.
 
-        Seeds only complete user/assistant turns (no system / prompt_echo / tool).
-        Cross-run tool chains are incomplete and break model APIs, so they are
-        omitted from L1. Used by the worker when constructing ``AdapterContext``.
+        Seeds only complete user/assistant turns (no system / prompt_echo /
+        reasoning / tool). Cross-run tool chains are incomplete and break model
+        APIs, so they are omitted from L1. Reasoning blocks stay in the Run
+        transcript for the console but are not replayed into the next prompt.
+        Used by the worker when constructing ``AdapterContext``.
         """
         max_messages = get_settings().thread_messages_max
         # Over-fetch slightly so role filtering still fills the cap.
@@ -246,7 +248,7 @@ class ThreadService:
         messages: list[dict[str, Any]] = []
         for msg, _run in result.all():
             extra = msg.extra or {}
-            if extra.get("kind") == "prompt_echo":
+            if extra.get("kind") in ("prompt_echo", "reasoning"):
                 continue
             payload = message_row_to_dict(msg)
             # Drop incomplete tool-call metadata from prior runs.

--- a/backend/tests/test_langgraph_adapter.py
+++ b/backend/tests/test_langgraph_adapter.py
@@ -238,6 +238,7 @@ async def test_langgraph_streams_token_deltas_and_defers_step_tokens():
     ]
     assert len(token_events) > 0
     assert all(e["step_index"] == 0 for e in token_events)
+    assert all(e.get("part", "text") == "text" for e in token_events)
     reply = (result.output or {}).get("reply", "")
     assert "".join(e["delta"] for e in token_events) == reply
 
@@ -257,6 +258,49 @@ async def test_langgraph_streams_token_deltas_and_defers_step_tokens():
     ]
     assert completed[0]["tokens_in"] == updated[0]["tokens_in"]
     assert completed[0]["tokens_out"] == updated[0]["tokens_out"]
+
+
+@pytest.mark.asyncio
+async def test_langgraph_streams_and_persists_reasoning_blocks():
+    adapter = LangGraphAdapter()
+    ctx = _RecordingContext()
+    ctx.agent_config = {
+        "model": "openai/gpt-4o-mini",
+        "stream_tokens": True,
+        "stream_reasoning": True,
+    }
+    result = await adapter.run(ctx)
+    assert result.status == RunStatus.SUCCEEDED
+
+    reasoning_deltas = [
+        data
+        for event, data in ctx.events
+        if event == "token.delta" and data.get("part") == "reasoning"
+    ]
+    text_deltas = [
+        data
+        for event, data in ctx.events
+        if event == "token.delta" and data.get("part", "text") == "text"
+    ]
+    assert reasoning_deltas
+    assert text_deltas
+    reply = (result.output or {}).get("reply", "")
+    assert "".join(e["delta"] for e in text_deltas) == reply
+
+    reasoning_msgs = [
+        m
+        for m in _message_events(ctx.events)
+        if (m.get("extra") or {}).get("kind") == "reasoning"
+    ]
+    assert len(reasoning_msgs) == 1
+    assert "".join(e["delta"] for e in reasoning_deltas) == reasoning_msgs[0]["content"]
+
+    assistant = [
+        m
+        for m in _message_events(ctx.events)
+        if m["role"] == "assistant" and (m.get("extra") or {}).get("kind") != "reasoning"
+    ]
+    assert assistant[-1]["content"] == reply
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_threads.py
+++ b/backend/tests/test_threads.py
@@ -243,7 +243,7 @@ async def test_thread_message_pagination(client):
 
 
 @pytest.mark.asyncio
-async def test_load_thread_window_skips_tool_and_prompt_echo():
+async def test_load_thread_window_skips_tool_prompt_echo_and_reasoning():
     from app.db.base import Base
     from app.db.session import SessionLocal, engine
     from app.models import Agent, Message, Run, Thread
@@ -301,7 +301,14 @@ async def test_load_thread_window_skips_tool_and_prompt_echo():
                     content='{"ok":true}',
                     tool_call_id="c1",
                 ),
-                Message(run_id=run.id, index=4, role="assistant", content="done"),
+                Message(
+                    run_id=run.id,
+                    index=4,
+                    role="assistant",
+                    content="secret chain of thought",
+                    extra={"kind": "reasoning"},
+                ),
+                Message(run_id=run.id, index=5, role="assistant", content="done"),
             ]
         )
         await session.commit()

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -381,8 +381,14 @@ The supported `type` values are:
 `token.delta` is SSE-only (not persisted). Payload:
 
 ```json
-{ "step_index": 0, "delta": "Hel", "role": "assistant" }
+{ "step_index": 0, "delta": "Hel", "role": "assistant", "part": "text" }
 ```
+
+`part` discriminates fine-grained streams: `"text"` (default, visible reply)
+or `"reasoning"` (model thinking / chain-of-thought). Finished reasoning is
+persisted as a `message.created` with `extra.kind = "reasoning"` so the
+console can show a collapsible block after reconnect; live deltas remain
+ephemeral.
 
 `step.updated` flushes deferred metrics on a running step (tokens, latency)
 before `step.completed`:
@@ -592,10 +598,14 @@ ops dashboards.
   name: string | null;
   content: string;
   tool_call_id: string | null;
-  extra: Record<string, unknown>;
+  extra: Record<string, unknown>;  // kind?: "prompt_echo" | "reasoning" | …
   created_at: string;
 }
 ```
+
+`extra.kind = "reasoning"` marks a persisted reasoning / thinking block
+(content is the full chain-of-thought). These rows stay on the Run transcript
+for the console but are excluded from Thread L1 window seeding.
 
 ### `MessagePage`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,6 +226,28 @@ When `feedback` is enabled and recoverable observations exhaust
 `max_tool_rounds` without a final model reply, the run fails with
 `tool_recovery_exhausted: reached max_tool_rounds=N`.
 
+## Fine-grained streaming (reasoning blocks)
+
+`token.delta` carries an optional `part` field:
+
+| `part` | Meaning |
+| --- | --- |
+| `text` (default) | Visible assistant reply chunk |
+| `reasoning` | Model thinking / chain-of-thought chunk |
+
+Deltas stay SSE-only (no Redis replay log, no DB row). When the model finishes,
+LangGraph persists a `message.created` with `extra.kind = "reasoning"` (full
+text) before the visible assistant message. OpenAI-compatible providers that
+emit `reasoning_content` / `reasoning` / `thinking` on deltas are mapped
+automatically; mock mode uses `stream_reasoning: true` in agent config.
+
+The console folds reasoning in Messages and applies live `token.delta` drafts
+so operators see thinking as it streams. Thread L1 seeding skips reasoning
+rows (same as `prompt_echo`) so chain-of-thought is not replayed into the next
+prompt.
+
+Multimodal attachment persistence is still outstanding.
+
 ## Unit tests
 
 The Python test suite in `backend/tests/` exercises adapter and queue logic

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -143,6 +143,9 @@ stateDiagram-v2
 - **`Message.step_id` is optional** so an adapter can attach a message to a
   specific node tick when it makes sense, while keeping the run-level
   ordering authoritative.
+- **`Message.extra.kind = "reasoning"`** persists a finished thinking block
+  (content = full reasoning text). Live chunks use SSE `token.delta` with
+  `part: "reasoning"` and are not written to Redis replay or Postgres.
 - **`Thread` groups Runs for L1 short memory.** `Run.thread_id` is optional;
   when set, the worker seeds `AdapterContext.thread_messages` from prior runs
   in the same thread (window-trimmed). Messages remain Run-scoped rows.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -77,9 +77,9 @@
 
 - [ ] Run 对比与回归套件
 - [ ] Agent 记忆服务（M1 Thread ✅；M2/M3 情景摘要 + 语义事实 + 文档 RAG 待做）
-- [ ] 模型路由 / fallback 策略
+- [x] 模型路由 / fallback 策略
 - [ ] 定时与批量 Run
-- [ ] 细粒度流式：推理块、多模态附件（DB 持久化）
+- [x] 细粒度流式：推理块（`token.delta.part` + `Message.extra.kind=reasoning`）；多模态附件（DB 持久化）待做
 
 ## Agent Memory 专项
 

--- a/frontend/components/EventStream.tsx
+++ b/frontend/components/EventStream.tsx
@@ -25,6 +25,12 @@ function formatEventData(type: string, data: Record<string, unknown>): string {
     if (stateKeys) parts.push(`state keys: ${stateKeys}`);
     return parts.join(" · ");
   }
+  if (type === "token.delta") {
+    const part = data.part === "reasoning" ? "reasoning" : "text";
+    const delta = typeof data.delta === "string" ? data.delta : "";
+    const preview = delta.length > 40 ? `${delta.slice(0, 40)}…` : delta;
+    return `part=${part} · ${JSON.stringify(preview)}`;
+  }
   return JSON.stringify(data);
 }
 

--- a/frontend/components/MessagesPanel.tsx
+++ b/frontend/components/MessagesPanel.tsx
@@ -16,6 +16,16 @@ function isPromptEcho(message: Message): boolean {
   return message.extra?.kind === "prompt_echo";
 }
 
+function isReasoning(message: Message): boolean {
+  const kind = message.extra?.kind;
+  return kind === "reasoning" || kind === "streaming_reasoning";
+}
+
+function isStreaming(message: Message): boolean {
+  const kind = message.extra?.kind;
+  return kind === "streaming" || kind === "streaming_reasoning";
+}
+
 function mergeMessages(...groups: Message[][]): Message[] {
   const byIndex = new Map<number, Message>();
   for (const group of groups) {
@@ -26,36 +36,42 @@ function mergeMessages(...groups: Message[][]): Message[] {
   return [...byIndex.values()].sort((a, b) => a.index - b.index);
 }
 
-function PromptEchoRow({
-  message,
+function CollapsibleBlock({
+  title,
+  meta,
+  content,
   expanded,
   onToggle,
+  dashed = false,
 }: {
-  message: Message;
+  title: string;
+  meta?: string | null;
+  content: string;
   expanded: boolean;
   onToggle: () => void;
+  dashed?: boolean;
 }) {
-  const node =
-    typeof message.extra.node === "string" ? message.extra.node : null;
-
   return (
-    <li className="rounded border border-dashed border-border bg-surface/60 p-2 text-sm">
+    <li
+      className={
+        dashed
+          ? "rounded border border-dashed border-border bg-surface/60 p-2 text-sm"
+          : "rounded border border-border bg-surface/80 p-2 text-sm"
+      }
+    >
       <button
         type="button"
         className="flex w-full items-center justify-between gap-2 text-left text-xs text-muted hover:text-foreground"
         onClick={onToggle}
       >
         <span>
-          {message.role} prompt echo
-          {node ? ` · ${node}` : ""}
-          <span className="ml-2 font-mono normal-case">#{message.index}</span>
+          {title}
+          {meta ? ` · ${meta}` : ""}
         </span>
         <span>{expanded ? "Hide" : "Show"}</span>
       </button>
       {expanded ? (
-        <div className="mt-2 whitespace-pre-wrap text-foreground">
-          {message.content}
-        </div>
+        <div className="mt-2 whitespace-pre-wrap text-foreground">{content}</div>
       ) : null}
     </li>
   );
@@ -78,7 +94,7 @@ export function MessagesPanel({
   const [nextCursor, setNextCursor] = useState<number | null>(null);
   const [hasMore, setHasMore] = useState(messagesTruncated);
   const [loading, setLoading] = useState(false);
-  const [expandedEchoes, setExpandedEchoes] = useState<Set<number>>(
+  const [expanded, setExpanded] = useState<Set<string>>(
     () => new Set(),
   );
 
@@ -86,7 +102,7 @@ export function MessagesPanel({
     setOlder([]);
     setNextCursor(null);
     setHasMore(messagesTruncated);
-    setExpandedEchoes(new Set());
+    setExpanded(new Set());
   }, [runId, messagesTruncated]);
 
   const displayed = useMemo(
@@ -96,6 +112,10 @@ export function MessagesPanel({
 
   const promptEchoCount = useMemo(
     () => displayed.filter(isPromptEcho).length,
+    [displayed],
+  );
+  const reasoningCount = useMemo(
+    () => displayed.filter(isReasoning).length,
     [displayed],
   );
 
@@ -115,13 +135,13 @@ export function MessagesPanel({
     }
   }
 
-  function toggleEcho(index: number) {
-    setExpandedEchoes((prev) => {
+  function toggle(key: string) {
+    setExpanded((prev) => {
       const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
+      if (next.has(key)) {
+        next.delete(key);
       } else {
-        next.add(index);
+        next.add(key);
       }
       return next;
     });
@@ -136,6 +156,9 @@ export function MessagesPanel({
             {displayed.length} shown
             {promptEchoCount > 0
               ? ` · ${promptEchoCount} prompt echo${promptEchoCount === 1 ? "" : "es"} collapsed`
+              : ""}
+            {reasoningCount > 0
+              ? ` · ${reasoningCount} reasoning block${reasoningCount === 1 ? "" : "s"}`
               : ""}
             {hasMore ? " · older available" : ""}
           </span>
@@ -154,21 +177,51 @@ export function MessagesPanel({
       ) : null}
 
       <ol className="max-h-[32rem] space-y-2 overflow-y-auto pr-1">
-        {displayed.map((message) =>
-          isPromptEcho(message) ? (
-            <PromptEchoRow
-              key={message.id}
-              message={message}
-              expanded={expandedEchoes.has(message.index)}
-              onToggle={() => toggleEcho(message.index)}
-            />
-          ) : (
+        {displayed.map((message) => {
+          const key = message.id;
+          if (isPromptEcho(message)) {
+            const node =
+              typeof message.extra.node === "string" ? message.extra.node : null;
+            return (
+              <CollapsibleBlock
+                key={key}
+                title={`${message.role} prompt echo`}
+                meta={
+                  node
+                    ? `${node} #${message.index}`
+                    : `#${message.index}`
+                }
+                content={message.content}
+                expanded={expanded.has(key)}
+                onToggle={() => toggle(key)}
+                dashed
+              />
+            );
+          }
+          if (isReasoning(message)) {
+            return (
+              <CollapsibleBlock
+                key={key}
+                title={
+                  isStreaming(message)
+                    ? "assistant reasoning (streaming…)"
+                    : "assistant reasoning"
+                }
+                meta={`#${message.index}`}
+                content={message.content}
+                expanded={expanded.has(key) || isStreaming(message)}
+                onToggle={() => toggle(key)}
+              />
+            );
+          }
+          return (
             <li
-              key={message.id}
+              key={key}
               className="rounded border border-border bg-surface p-3 text-sm"
             >
               <div className="mb-1 text-xs uppercase tracking-wide text-muted">
                 {message.role}
+                {isStreaming(message) ? " · streaming…" : ""}
                 {message.name ? ` · ${message.name}` : ""}
                 {message.step_id ? (
                   <span className="ml-2 font-mono normal-case">
@@ -187,8 +240,8 @@ export function MessagesPanel({
               </div>
               <div className="whitespace-pre-wrap">{message.content}</div>
             </li>
-          ),
-        )}
+          );
+        })}
       </ol>
 
       {displayed.length === 0 ? (

--- a/frontend/lib/run-events.ts
+++ b/frontend/lib/run-events.ts
@@ -181,6 +181,71 @@ function appendMessage(messages: Message[], data: Record<string, unknown>, at: s
   return [...messages, message].sort((a, b) => a.index - b.index);
 }
 
+function streamingDraftId(stepIndex: number, part: "text" | "reasoning"): string {
+  return `sse-stream-${stepIndex}-${part}`;
+}
+
+function appendTokenDelta(
+  messages: Message[],
+  data: Record<string, unknown>,
+  at: string,
+): Message[] {
+  const stepIndex = data.step_index;
+  if (typeof stepIndex !== "number") return messages;
+  const delta = typeof data.delta === "string" ? data.delta : "";
+  if (!delta) return messages;
+
+  const part = data.part === "reasoning" ? "reasoning" : "text";
+  const draftId = streamingDraftId(stepIndex, part);
+  const existing = messages.find((message) => message.id === draftId);
+  if (existing) {
+    return messages.map((message) =>
+      message.id === draftId
+        ? { ...message, content: message.content + delta, created_at: at }
+        : message,
+    );
+  }
+
+  const index =
+    messages.length > 0
+      ? Math.max(...messages.map((message) => message.index)) + 1
+      : 0;
+
+  const draft: Message = {
+    id: draftId,
+    index,
+    step_id: null,
+    role: "assistant",
+    name: null,
+    content: delta,
+    tool_call_id: null,
+    extra: {
+      kind: part === "reasoning" ? "streaming_reasoning" : "streaming",
+      step_index: stepIndex,
+    },
+    created_at: at,
+  };
+  return [...messages, draft].sort((a, b) => a.index - b.index);
+}
+
+function dropStreamingDrafts(
+  messages: Message[],
+  data: Record<string, unknown>,
+): Message[] {
+  const stepIndex =
+    typeof data.step_index === "number" ? data.step_index : null;
+  if (stepIndex == null) return messages;
+
+  const kind = asRecord(data.extra).kind;
+  const dropIds = new Set<string>();
+  if (kind === "reasoning") {
+    dropIds.add(streamingDraftId(stepIndex, "reasoning"));
+  } else {
+    dropIds.add(streamingDraftId(stepIndex, "text"));
+  }
+  return messages.filter((message) => !dropIds.has(message.id));
+}
+
 function appendToolCall(step: Step, data: Record<string, unknown>): ToolCall {
   const callId =
     typeof data.call_id === "string" && data.call_id
@@ -411,10 +476,19 @@ export function applyRunEvent(run: Run, event: RunEvent): Run {
         usage: aggregateUsageFromSteps(steps),
       };
     }
+    case "token.delta":
+      return {
+        ...next,
+        messages: appendTokenDelta(run.messages, data, at),
+      };
     case "message.created":
       return {
         ...next,
-        messages: appendMessage(run.messages, data, at),
+        messages: appendMessage(
+          dropStreamingDrafts(run.messages, data),
+          data,
+          at,
+        ),
       };
     case "tool_call.started": {
       const stepIndex = data.step_index;


### PR DESCRIPTION
## Summary

- Add fine-grained SSE streaming for model reasoning (`token.delta.part`) and persist finished thinking as `Message.extra.kind=reasoning`.
- Show live reasoning/text drafts in the console, with collapsible reasoning blocks after reconnect.

## Changes

- **Worker:** `emit_token_delta` accepts `part` (`text` | `reasoning`); LangGraph maps OpenAI-compatible `reasoning_content` / `reasoning` / `thinking` and optional mock `stream_reasoning`.
- **Persistence:** finished reasoning is written before the visible assistant message; Thread L1 window seeding skips reasoning rows.
- **Console:** Messages panel folds reasoning; `applyRunEvent` applies live `token.delta` drafts until `message.created` replaces them.
- **Docs:** api-contract, architecture, data-model, and plan updated for the reasoning-block slice (multimodal attachments still open).

## Test plan

- [ ] `cd backend && uv run pytest tests/test_langgraph_adapter.py tests/test_threads.py`
- [ ] Create a LangGraph run with `stream_tokens: true` and `stream_reasoning: true`; confirm SSE shows `part=reasoning` then `part=text`
- [ ] On the run detail page, confirm a collapsible reasoning block appears and live text streams before `message.created`
- [ ] Reconnect SSE mid-run and confirm persisted reasoning survives while ephemeral deltas do not replay
